### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN npm install
 COPY . .
 
 # Build the Tree.js app
-RUN npm run build:app
+RUN npm run build
 
 # Install a simple HTTP server for serving static content
 RUN npm install -g http-server

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build:app": "vite build --config vite.app.config.js",
     "build:lib": "vite build --config vite.lib.config.js",
     "build:watch": "vite build --config vite.lib.config.js --watch",
+    "build": "npm run build:lib && npm run build:app",
     "app": "npm run build:lib && vite --config vite.app.config.js",
     "preview": "vite preview"
   },


### PR DESCRIPTION
When attempting to run in docker i was getting:
> 1.772 [vite:load-fallback] Could not load /usr/src/app/build/ez-tree.es.js (imported by src/app/scene.js): ENOENT: no such file or directory, open '/usr/src/app/build/ez-tree.es.js'
1.772 Error: Could not load /usr/src/app/build/ez-tree.es.js (imported by src/app/scene.js): ENOENT: no such file or directory, open '/usr/src/app/build/ez-tree.es.js'

This was caused by the Dockerfile not building the lib before the app on a clean install.