### PR TITLE
Remove deprecated version attribute

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   tree-gen-app:
     build:


### PR DESCRIPTION
It's not used anymore and trying to build with it gives the following warning:
> the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion