### PR TITLE
Use custom rounded normals for leaves

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dgreenheck/ez-tree",
-  "version": "1.1.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dgreenheck/ez-tree",
-      "version": "1.1.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/three": "^0.169.0",
@@ -1842,7 +1842,6 @@
       "integrity": "sha512-WoinX7GeQOFMGznEcWA1WrTQCd/tpEbMkc3nuMs9BT0CPjMdSjPMTVClwWd4pgSQwJdP65SK9mTCNvItlr5o7w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -2073,7 +2072,6 @@
       "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dgreenheck/ez-tree",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dgreenheck/ez-tree",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/three": "^0.169.0",
@@ -1842,6 +1842,7 @@
       "integrity": "sha512-WoinX7GeQOFMGznEcWA1WrTQCd/tpEbMkc3nuMs9BT0CPjMdSjPMTVClwWd4pgSQwJdP65SK9mTCNvItlr5o7w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -2072,6 +2073,7 @@
       "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/app/ui.js
+++ b/src/app/ui.js
@@ -774,6 +774,13 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
   leavesSection.add(alphaTestSlider);
   controls.push({ control: alphaTestSlider, update: () => alphaTestSlider.setValue(tree.options.leaves.alphaTest) });
 
+  const roundedNormalsToggle = createToggle('Rounded Normals', tree.options.leaves.roundedNormals, (val) => {
+    tree.options.leaves.roundedNormals = val;
+    onChange();
+  });
+  leavesSection.add(roundedNormalsToggle);
+  controls.push({ control: roundedNormalsToggle, update: () => roundedNormalsToggle.setValue(tree.options.leaves.roundedNormals) });
+
   parametersTab.appendChild(leavesSection.element);
 
   // ----- Trellis Section -----

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -140,6 +140,9 @@ export default class TreeOptions {
 
       // Controls transparency of leaf texture
       alphaTest: 0.5,
+
+      // Calculates custom normals to imply a rounded canopy shape
+      roundedNormals: true,
     };
 
     // Trellis parameters

--- a/src/lib/tree.js
+++ b/src/lib/tree.js
@@ -479,10 +479,11 @@ export class Tree extends THREE.Group {
 
       // The normal vectors are an average of the direction of the leaf and the directions to the individual vertices.
       // This creates a nice rounded shape while maintaining the canopy shape as a whole.
-      let n1 = new THREE.Vector3().copy(n).add(v[0]).sub(origin).normalize();
-      let n2 = new THREE.Vector3().copy(n).add(v[1]).sub(origin).normalize();
-      let n3 = new THREE.Vector3().copy(n).add(v[2]).sub(origin).normalize();
-      let n4 = new THREE.Vector3().copy(n).add(v[3]).sub(origin).normalize();
+      const roundedNormals = this.options.leaves.roundedNormals;
+      let n1 = roundedNormals ? new THREE.Vector3().copy(n).add(v[0]).sub(origin).normalize() : n;
+      let n2 = roundedNormals ? new THREE.Vector3().copy(n).add(v[1]).sub(origin).normalize() : n;
+      let n3 = roundedNormals ? new THREE.Vector3().copy(n).add(v[2]).sub(origin).normalize() : n;
+      let n4 = roundedNormals ? new THREE.Vector3().copy(n).add(v[3]).sub(origin).normalize() : n;
 
       this.leaves.normals.push(
         n1.x,
@@ -589,15 +590,11 @@ export class Tree extends THREE.Group {
     g.setIndex(
       new THREE.BufferAttribute(new Uint16Array(this.leaves.indices), 1),
     );
-    if (this.options.leaves.roundedNormals) {
-      g.setAttribute(
-        'normal',
-        new THREE.BufferAttribute(new Float32Array(this.leaves.normals), 3),
-      );
-    } else {
-      // If our custom rounded normals are not applied, compute normals from the vertices.
-      g.computeVertexNormals();
-    }
+    g.setAttribute(
+      'normal',
+      new THREE.BufferAttribute(new Float32Array(this.leaves.normals), 3),
+    );
+
     g.computeBoundingSphere();
 
     const mat = new THREE.MeshPhongMaterial({
@@ -742,58 +739,14 @@ export class Tree extends THREE.Group {
         `
       );
 
-      // Disable the backface normal flip line in "normal_fragment_begin" if we use custom normals
-      shader.fragmentShader = `
-      uniform bool uCustomNormals;
-      ` + shader.fragmentShader;
-
-      shader.fragmentShader = shader.fragmentShader.replace("#include <normal_fragment_begin>", `
-        float faceDirection = gl_FrontFacing ? 1.0 : - 1.0;
-        #ifdef FLAT_SHADED
-          vec3 fdx = dFdx( vViewPosition );
-          vec3 fdy = dFdy( vViewPosition );
-          vec3 normal = normalize( cross( fdx, fdy ) );
-        #else
-          vec3 normal = normalize( vNormal );
-          #ifdef DOUBLE_SIDED
-            if (!uCustomNormals) {
-              normal *= faceDirection;
-            }
-          #endif
-        #endif
-        #if defined( USE_NORMALMAP_TANGENTSPACE ) || defined( USE_CLEARCOAT_NORMALMAP ) || defined( USE_ANISOTROPY )
-          #ifdef USE_TANGENT
-            mat3 tbn = mat3( normalize( vTangent ), normalize( vBitangent ), normal );
-          #else
-            mat3 tbn = getTangentFrame( - vViewPosition, normal,
-            #if defined( USE_NORMALMAP )
-              vNormalMapUv
-            #elif defined( USE_CLEARCOAT_NORMALMAP )
-              vClearcoatNormalMapUv
-            #else
-              vUv
-            #endif
-            );
-          #endif
-          #if defined( DOUBLE_SIDED ) && ! defined( FLAT_SHADED )
-            tbn[0] *= faceDirection;
-            tbn[1] *= faceDirection;
-          #endif
-        #endif
-        #ifdef USE_CLEARCOAT_NORMALMAP
-          #ifdef USE_TANGENT
-            mat3 tbn2 = mat3( normalize( vTangent ), normalize( vBitangent ), normal );
-          #else
-            mat3 tbn2 = getTangentFrame( - vViewPosition, normal, vClearcoatNormalMapUv );
-          #endif
-          #if defined( DOUBLE_SIDED ) && ! defined( FLAT_SHADED )
-            tbn2[0] *= faceDirection;
-            tbn2[1] *= faceDirection;
-          #endif
-        #endif
-        // non perturbed normal for clearcoat among others
-        vec3 nonPerturbedNormal = normal;
-      `);
+      // Skip the backface normal flip in normal_fragment_begin when using custom normals
+      shader.fragmentShader = `uniform bool uCustomNormals;\n` + shader.fragmentShader.replace(
+        '#include <normal_fragment_begin>',
+        THREE.ShaderChunk.normal_fragment_begin.replace(
+          'normal *= faceDirection;',
+          'if (!uCustomNormals) { normal *= faceDirection; }'
+        )
+      );
 
       mat.userData.shader = shader;
     };

--- a/src/lib/tree.js
+++ b/src/lib/tree.js
@@ -476,19 +476,27 @@ export class Tree extends THREE.Group {
       );
 
       const n = new THREE.Vector3(0, 0, 1).applyEuler(orientation);
+
+      // The normal vectors are an average of the direction of the leaf and the directions to the individual vertices.
+      // This creates a nice rounded shape while maintaining the canopy shape as a whole.
+      let n1 = new THREE.Vector3().copy(n).add(v[0]).sub(origin).normalize();
+      let n2 = new THREE.Vector3().copy(n).add(v[1]).sub(origin).normalize();
+      let n3 = new THREE.Vector3().copy(n).add(v[2]).sub(origin).normalize();
+      let n4 = new THREE.Vector3().copy(n).add(v[3]).sub(origin).normalize();
+
       this.leaves.normals.push(
-        n.x,
-        n.y,
-        n.z,
-        n.x,
-        n.y,
-        n.z,
-        n.x,
-        n.y,
-        n.z,
-        n.x,
-        n.y,
-        n.z,
+        n1.x,
+        n1.y,
+        n1.z,
+        n2.x,
+        n2.y,
+        n2.z,
+        n3.x,
+        n3.y,
+        n3.z,
+        n4.x,
+        n4.y,
+        n4.z,
       );
       this.leaves.uvs.push(0, 1, 0, 0, 1, 0, 1, 1);
       this.leaves.indices.push(i, i + 1, i + 2, i, i + 2, i + 3);
@@ -581,7 +589,15 @@ export class Tree extends THREE.Group {
     g.setIndex(
       new THREE.BufferAttribute(new Uint16Array(this.leaves.indices), 1),
     );
-    g.computeVertexNormals();
+    if (this.options.leaves.roundedNormals) {
+      g.setAttribute(
+        'normal',
+        new THREE.BufferAttribute(new Float32Array(this.leaves.normals), 3),
+      );
+    } else {
+      // If our custom rounded normals are not applied, compute normals from the vertices.
+      g.computeVertexNormals();
+    }
     g.computeBoundingSphere();
 
     const mat = new THREE.MeshPhongMaterial({
@@ -599,6 +615,7 @@ export class Tree extends THREE.Group {
       shader.uniforms.uWindStrength = { value: new THREE.Vector3(0.5, 0, 0.5) };
       shader.uniforms.uWindFrequency = { value: 0.5 };
       shader.uniforms.uWindScale = { value: 70 };
+      shader.uniforms.uCustomNormals = { value: this.options.leaves.roundedNormals };
 
       shader.vertexShader = `
         uniform float uTime;
@@ -724,6 +741,59 @@ export class Tree extends THREE.Group {
         gl_Position = projectionMatrix * mvPosition;
         `
       );
+
+      // Disable the backface normal flip line in "normal_fragment_begin" if we use custom normals
+      shader.fragmentShader = `
+      uniform bool uCustomNormals;
+      ` + shader.fragmentShader;
+
+      shader.fragmentShader = shader.fragmentShader.replace("#include <normal_fragment_begin>", `
+        float faceDirection = gl_FrontFacing ? 1.0 : - 1.0;
+        #ifdef FLAT_SHADED
+          vec3 fdx = dFdx( vViewPosition );
+          vec3 fdy = dFdy( vViewPosition );
+          vec3 normal = normalize( cross( fdx, fdy ) );
+        #else
+          vec3 normal = normalize( vNormal );
+          #ifdef DOUBLE_SIDED
+            if (!uCustomNormals) {
+              normal *= faceDirection;
+            }
+          #endif
+        #endif
+        #if defined( USE_NORMALMAP_TANGENTSPACE ) || defined( USE_CLEARCOAT_NORMALMAP ) || defined( USE_ANISOTROPY )
+          #ifdef USE_TANGENT
+            mat3 tbn = mat3( normalize( vTangent ), normalize( vBitangent ), normal );
+          #else
+            mat3 tbn = getTangentFrame( - vViewPosition, normal,
+            #if defined( USE_NORMALMAP )
+              vNormalMapUv
+            #elif defined( USE_CLEARCOAT_NORMALMAP )
+              vClearcoatNormalMapUv
+            #else
+              vUv
+            #endif
+            );
+          #endif
+          #if defined( DOUBLE_SIDED ) && ! defined( FLAT_SHADED )
+            tbn[0] *= faceDirection;
+            tbn[1] *= faceDirection;
+          #endif
+        #endif
+        #ifdef USE_CLEARCOAT_NORMALMAP
+          #ifdef USE_TANGENT
+            mat3 tbn2 = mat3( normalize( vTangent ), normalize( vBitangent ), normal );
+          #else
+            mat3 tbn2 = getTangentFrame( - vViewPosition, normal, vClearcoatNormalMapUv );
+          #endif
+          #if defined( DOUBLE_SIDED ) && ! defined( FLAT_SHADED )
+            tbn2[0] *= faceDirection;
+            tbn2[1] *= faceDirection;
+          #endif
+        #endif
+        // non perturbed normal for clearcoat among others
+        vec3 nonPerturbedNormal = normal;
+      `);
 
       mat.userData.shader = shader;
     };


### PR DESCRIPTION
Previously, the leaf billboards had their normals generated directly from the mesh. While this is geometrically correct, it does not match what the billboards are trying to imply: the leaf billboards are geometrically flat, but trying to imply a dense, volumetric canopy. Therefore, shading these billboards as flat objects does not produce the intended result.

To fix this, this PR calculates custom normals for the leaf meshes. These custom normals are based on the direction of the leaf shoot and the position of the vertex within the individual leaf, producing a smoothly shaded canopy. This makes lighting look more realistic and understandable.

The fragment shader for the leaves was adapted to remove the backface normal flip, since this is not desired when using custom normals. This graphic I created for a similar PR elsewhere explains why:

<img width="1219" height="678" alt="image" src="https://github.com/user-attachments/assets/4e82d599-4365-4d90-885f-f1252ac2d878" />

Rounded normals are enabled by default because I would argue that they are desirable most of the time, however they can be disabled in the leaf settings to restore the old behavior.

## Comparisons

| Before | After |
| ---------- | ------- |
| <img width="995" height="1076" alt="image" src="https://github.com/user-attachments/assets/6d486ac8-575f-4504-a904-c492cea3d8a1" /> | <img width="995" height="1076" alt="image" src="https://github.com/user-attachments/assets/1f8149a3-174e-4450-8b2b-cccf636ab984" /> |
| <img width="995" height="1076" alt="image" src="https://github.com/user-attachments/assets/85a9957c-216b-429c-8dfa-5317b54592f9" /> | <img width="995" height="1076" alt="image" src="https://github.com/user-attachments/assets/7be882c6-3283-42ca-a0b8-4a780d76a9e7" /> |
| <img width="995" height="1076" alt="image" src="https://github.com/user-attachments/assets/d2a8b010-e250-474d-9474-362d67644b2b" /> | <img width="995" height="1076" alt="image" src="https://github.com/user-attachments/assets/25f1bb63-e38d-4287-873f-b518f9d6539f" /> | 
| <img width="995" height="1076" alt="image" src="https://github.com/user-attachments/assets/33c05e79-807d-4ef7-a0c1-deebe17556ba" /> | <img width="995" height="1076" alt="image" src="https://github.com/user-attachments/assets/adcc1839-52ed-47c9-90c7-a729a7182329" /> |