### PR TITLE
Add geometric LOD support for trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Breaking:** removed `BarkType` and `LeafType` enums and the bundled-texture lookup. Callers must now load `THREE.Texture` instances themselves and assign them to `options.bark.maps` / `options.leaves.map`. `bark.type` / `leaves.type` strings are still carried through presets but are now purely informational identifiers the host app can use to resolve textures.
 - Bark UVs now scale with `branch.radius` (integer-rounded per branch) so bark feature size stays consistent across thick trunks and thin twigs; `bark.textureScale.x` now means "wraps per unit radius" rather than "wraps per branch" (existing preset values may need re-tuning).
 - Demo app ships with 11 CC0 bark variants from ambientcg.com under `src/app/public/textures/bark/` with attribution in `src/app/public/textures/LICENSE.md`, tracked via Git LFS.
+- Trimmed the bark texture sets to the maps the demo actually uses (color, GL normal, roughness) — removed the ambient-occlusion, displacement, and DirectX normal variants (~15 MB). The library still applies an `ao` map when a caller supplies one.
 
 ### Rendering Improvements
 
+- Bark, leaf, ground, and grass materials switched from `MeshPhongMaterial` to `MeshStandardMaterial` (PBR). Bark roughness maps now actually affect shading, and GLB exports round-trip cleanly without the exporter's Phong-conversion warnings.
 - Leaves use custom rounded normals for softer, canopy-shaped shading (#43).
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Tree.generateLODs(levels)` generates the tree at multiple levels of detail hosted in a `THREE.LOD` inside the tree group, with automatic distance-based switching. All levels are meshed from a single skeleton (identical silhouette, no popping) and share one bark and one leaf material so `update()` animates wind at every level. Default levels (`Tree.defaultLODLevels`) reduce to ~40% and ~20% of the full triangle count at 100 and 250 units.
+- `Tree.createGeometry(detail)` returns raw `{ branches, leaves }` `BufferGeometry` pairs at any detail level (`sectionStride`, `segmentFactor`, `leafStride`, `leafScale`, `billboard`) for external instancing or custom LOD systems.
+- The demo app's background forest now uses `generateLODs()`.
+- Demo app: viewport stats overlay showing live triangle/vertex counts with buttons to preview each LOD level on the hero tree, an "Export LODs (ZIP)" button that downloads one GLB per LOD level, and the GLB export button now always exports full detail regardless of the active LOD preview.
 - `bark.maps = { color, ao, normal, roughness }` and `leaves.map` slots on `TreeOptions` accept caller-supplied `THREE.Texture` instances; the library no longer bundles any textures.
 - `npm run dev` script and Vite mode-based alias so the dev server resolves `@dgreenheck/ez-tree` directly to `src/lib/` source — instant HMR with no rebuild step.
 - Git LFS tracking for `src/app/public/textures/**/*.{jpg,png,jpeg}`.
@@ -16,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Tree generation is now split into a skeleton pass (all randomness) and a meshing pass (geometry emission). Output for a given seed is bit-identical to before; the undocumented internals `generateBranch`, `generateLeaf`, and `generateBranchIndices` were replaced by private methods.
 - **Breaking:** removed `BarkType` and `LeafType` enums and the bundled-texture lookup. Callers must now load `THREE.Texture` instances themselves and assign them to `options.bark.maps` / `options.leaves.map`. `bark.type` / `leaves.type` strings are still carried through presets but are now purely informational identifiers the host app can use to resolve textures.
 - Bark UVs now scale with `branch.radius` (integer-rounded per branch) so bark feature size stays consistent across thick trunks and thin twigs; `bark.textureScale.x` now means "wraps per unit radius" rather than "wraps per branch" (existing preset values may need re-tuning).
 - Reorganized `src/app/public/` into `audio/`, `fonts/`, `images/`, `icons/`, `models/`, `textures/{bark,ground,leaves}/`; browser/SEO well-known files remain at the root.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,50 +1,51 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Added
+### Levels of Detail
 
-- `Tree.generateLODs(levels)` generates the tree at multiple levels of detail hosted in a `THREE.LOD` inside the tree group, with automatic distance-based switching. All levels are meshed from a single skeleton (identical silhouette, no popping) and share one bark and one leaf material so `update()` animates wind at every level. Default levels (`Tree.defaultLODLevels`) reduce to ~40% and ~20% of the full triangle count at 100 and 250 units.
-- `Tree.createGeometry(detail)` returns raw `{ branches, leaves }` `BufferGeometry` pairs at any detail level (`sectionStride`, `segmentFactor`, `leafStride`, `leafScale`, `billboard`) for external instancing or custom LOD systems.
-- The demo app's background forest now uses `generateLODs()`.
-- Demo app: viewport stats overlay showing live triangle/vertex counts with buttons to preview each LOD level on the hero tree, an "Export LODs (ZIP)" button that downloads one GLB per LOD level, and the GLB export button now always exports full detail regardless of the active LOD preview.
-- `bark.maps = { color, ao, normal, roughness }` and `leaves.map` slots on `TreeOptions` accept caller-supplied `THREE.Texture` instances; the library no longer bundles any textures.
-- `npm run dev` script and Vite mode-based alias so the dev server resolves `@dgreenheck/ez-tree` directly to `src/lib/` source — instant HMR with no rebuild step.
-- Git LFS tracking for `src/app/public/textures/**/*.{jpg,png,jpeg}`.
-- Demo app ships with 11 CC0 bark variants from ambientcg.com under `src/app/public/textures/bark/` with attribution in `src/app/public/textures/LICENSE.md`.
+- **`Tree.generateLODs(levels)`** builds the tree at multiple levels of detail hosted in a `THREE.LOD` inside the tree group, with automatic distance-based switching.
+  - All levels are meshed from a single skeleton, so the silhouette is identical across levels and switches don't pop.
+  - All levels share one bark and one leaf material, so `update()` animates wind at every level.
+  - Default levels (`Tree.defaultLODLevels`) reduce to ~40% of the full triangle count at 100 units and ~20% at 250 units.
+- **`Tree.createGeometry(detail)`** returns raw `{ branches, leaves }` `BufferGeometry` pairs at any detail level (`sectionStride`, `segmentFactor`, `leafStride`, `leafScale`, `billboard`) for external instancing or custom LOD systems.
+- Internally, tree generation is now split into a skeleton pass (all randomness) and a meshing pass (geometry emission). Output for a given seed is bit-identical to before; the undocumented internals `generateBranch`, `generateLeaf`, and `generateBranchIndices` were replaced by private methods.
+- Demo app:
+  - The background forest generates with LODs.
+  - New viewport stats overlay shows live triangle/vertex counts, with buttons to preview each LOD level on the hero tree.
+  - New "Export LODs (ZIP)" button downloads one GLB per LOD level; "Export GLB (Full Detail)" always exports full detail regardless of the active LOD preview.
 
-### Changed
+### Texture System (breaking)
 
-- Tree generation is now split into a skeleton pass (all randomness) and a meshing pass (geometry emission). Output for a given seed is bit-identical to before; the undocumented internals `generateBranch`, `generateLeaf`, and `generateBranchIndices` were replaced by private methods.
+- The library no longer bundles any textures. `bark.maps = { color, ao, normal, roughness }` and `leaves.map` slots on `TreeOptions` accept caller-supplied `THREE.Texture` instances.
 - **Breaking:** removed `BarkType` and `LeafType` enums and the bundled-texture lookup. Callers must now load `THREE.Texture` instances themselves and assign them to `options.bark.maps` / `options.leaves.map`. `bark.type` / `leaves.type` strings are still carried through presets but are now purely informational identifiers the host app can use to resolve textures.
 - Bark UVs now scale with `branch.radius` (integer-rounded per branch) so bark feature size stays consistent across thick trunks and thin twigs; `bark.textureScale.x` now means "wraps per unit radius" rather than "wraps per branch" (existing preset values may need re-tuning).
+- Demo app ships with 11 CC0 bark variants from ambientcg.com under `src/app/public/textures/bark/` with attribution in `src/app/public/textures/LICENSE.md`, tracked via Git LFS.
+
+### Rendering Improvements
+
+- Leaves use custom rounded normals for softer, canopy-shaped shading (#43).
+
+### Bug Fixes
+
+- The growth force was not being applied correctly. Branches now grow uniformly in the same world direction.
+- Child branches and leaves are now placed with stratified sampling (with a permuted slot assignment) instead of fixed angular spacing, eliminating visible spirals and one-sided clumping.
+
+### Development & Tooling
+
+- `npm run dev` script and Vite mode-based alias so the dev server resolves `@dgreenheck/ez-tree` directly to `src/lib/` source — instant HMR with no rebuild step.
 - Reorganized `src/app/public/` into `audio/`, `fonts/`, `images/`, `icons/`, `models/`, `textures/{bark,ground,leaves}/`; browser/SEO well-known files remain at the root.
 - Updated Dockerfile to Node 24 and removed the obsolete `version` attribute from `docker-compose.yml`.
-- Use custom rounded normals for leaves for softer shading (#43).
-
-### Fixed
-
-- The growth force was not being applied correctly. Branches should now grow uniformly in the same world direction.
-- Child branches and leaves are now placed with stratified sampling (with a permuted slot assignment) instead of fixed angular spacing, eliminating visible spirals and one-sided clumping.
 
 ## [1.1.0] - 2026-01-14
 
-### Added
-
 - Trellis system with force attraction for branch growth, enabling guided/structured tree shapes (#35).
-
-### Changed
-
 - Disabled the trellis system on presets where it isn't applicable.
 
 ## [1.0.1] - 2026-01-14
-
-### Changed
 
 - Redesigned the application UI (#34).
 - Reduced bundled asset sizes by more than 50%.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Bug Fixes
 
+- GLB export silently failed for trees using the default bark: the Bark001 texture set has no ambient-occlusion file, the dev server masks the 404 by serving `index.html`, and GLTFExporter aborts on the resulting never-loaded texture. Texture loading now drops missing maps from the cache, and exports strip any never-loaded textures from materials for the duration of the export.
 - The growth force was not being applied correctly. Branches now grow uniformly in the same world direction.
 - Child branches and leaves are now placed with stratified sampling (with a permuted slot assignment) instead of fixed angular spacing, eliminating visible spirals and one-sided clumping.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,40 @@ scene.add(tree);
 
 Any time the tree parameters are changed, you must call `generate()` to regenerate the geometry.
 
+## Levels of Detail (LODs)
+
+For scenes with many trees, `generateLODs()` builds the tree at multiple levels of detail hosted in a `THREE.LOD` object inside the tree group. The renderer automatically switches levels based on camera distance. All levels are meshed from the same skeleton, so the tree's silhouette stays consistent across switches — distant levels just use fewer ring segments and fewer (but larger) leaves.
+
+```js
+const tree = new Tree();
+tree.loadPreset('Ash Medium');
+tree.generateLODs(); // instead of generate()
+scene.add(tree);
+```
+
+The default levels (`Tree.defaultLODLevels`) switch at 100 and 250 units, reducing to roughly 40% and 20% of the full triangle count. You can pass custom levels:
+
+```js
+tree.generateLODs([
+  { distance: 0, detail: {} }, // full detail
+  {
+    distance: 80,
+    hysteresis: 0.05,
+    detail: {
+      sectionStride: 3,    // sample every 3rd ring along each branch
+      segmentFactor: 0.75, // reduce radial segments to 75% (min 3)
+      leafStride: 2,       // keep every 2nd leaf...
+      leafScale: 1.4,      // ...enlarged to preserve canopy coverage
+      billboard: 'single', // drop the second crossed leaf quad
+    },
+  },
+]);
+```
+
+All LOD levels share one bark material and one leaf material, so `tree.update(time)` animates wind at every level. Calling `generate()` afterwards tears the LOD down and restores the single full-detail mesh pair (note that exporting a tree generated with `generateLODs()` to GLB will include every level).
+
+If you have your own LOD or instancing system, `tree.createGeometry(detail)` returns raw `{ branches, leaves }` `BufferGeometry` pairs at any detail level without touching the tree's own meshes.
+
 # Running Standalone App Locally
 
 To run the standalone app locally, you first need to build the EZ-Tree library before running the app.

--- a/src/app/grass.js
+++ b/src/app/grass.js
@@ -108,7 +108,7 @@ export class Grass extends THREE.Object3D {
       mesh.traverse((o) => {
         if (o.isMesh && o.material) {
           if (o.material.map) {
-            o.material = new THREE.MeshPhongMaterial({ map: o.material.map });
+            o.material = new THREE.MeshStandardMaterial({ map: o.material.map, metalness: 0.0, roughness: 1.0 });
           }
           this.appendWindShader(o.material);
         }
@@ -127,7 +127,7 @@ export class Grass extends THREE.Object3D {
   }
 
   generateGrass() {
-    const grassMaterial = new THREE.MeshPhongMaterial({
+    const grassMaterial = new THREE.MeshStandardMaterial({
       map: _grassMesh.material.map,
       // Add some emission so grass has some color when not lit
       emissive: new THREE.Color(0x308040),
@@ -136,6 +136,8 @@ export class Grass extends THREE.Object3D {
       alphaTest: 0.5,
       depthTest: true,
       depthWrite: true,
+      metalness: 0.0,
+      roughness: 1.0,
       side: THREE.DoubleSide
     });
 

--- a/src/app/ground.js
+++ b/src/app/ground.js
@@ -43,11 +43,12 @@ export class Ground extends THREE.Mesh {
 
     fetchAssets().then(() => {
       // Ground plane with procedural grass/dirt texture
-      this.material = new THREE.MeshPhongMaterial({
+      this.material = new THREE.MeshStandardMaterial({
         emissive: new THREE.Color(0xffffff),
         emissiveIntensity: 0.01,
         normalMap: _dirtNormal,
-        shininess: 0.1
+        metalness: 0.0,
+        roughness: 1.0
       });
 
       this.material.onBeforeCompile = (shader) => {

--- a/src/app/public/styles.css
+++ b/src/app/public/styles.css
@@ -996,3 +996,91 @@ a {
     min-width: 38px;
   }
 }
+/* ============================================================================
+   Stats Overlay (viewport HUD with LOD preview switching)
+   ============================================================================ */
+
+#stats-overlay {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background: var(--panel-bg);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-xl);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.stats-counts {
+  display: flex;
+  gap: var(--spacing-lg);
+}
+
+.stats-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.stats-value {
+  font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+  font-size: 1.25em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.2;
+}
+
+.stats-label {
+  font-size: 0.7em;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+
+.lod-switcher {
+  display: flex;
+  gap: 2px;
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius-sm);
+  padding: 2px;
+}
+
+.lod-button {
+  flex: 1;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: transparent;
+  border: none;
+  border-radius: calc(var(--radius-sm) - 2px);
+  color: var(--text-secondary);
+  font-size: 0.75em;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.lod-button:hover {
+  color: var(--text-primary);
+  background: var(--section-hover);
+}
+
+.lod-button.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+@media (max-width: 800px) {
+  #stats-overlay {
+    padding: var(--spacing-sm) var(--spacing-md);
+  }
+
+  .stats-value {
+    font-size: 1em;
+  }
+}

--- a/src/app/public/textures/bark/Bark001_1K-JPG/Bark001_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark001_1K-JPG/Bark001_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9376be8609cd3e0fe3b4d28902676089dd38db64163865e8d05374dedf78b58
-size 418260

--- a/src/app/public/textures/bark/Bark001_1K-JPG/Bark001_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark001_1K-JPG/Bark001_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c4b974442abb3609df973ce169a603cff3626a9d4ed6128563018811144346b0
-size 1271049

--- a/src/app/public/textures/bark/Bark002_1K-JPG/Bark002_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark002_1K-JPG/Bark002_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9eb76535ddabf3eab1f11be6d46e4866bacd5ed8229910a5e4e3471ba36db37
-size 602552

--- a/src/app/public/textures/bark/Bark002_1K-JPG/Bark002_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark002_1K-JPG/Bark002_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3310597dbbc1b3576b3e66cfd90d04837c0c8b8ae2e91a64a08384b6cd6470fa
-size 406525

--- a/src/app/public/textures/bark/Bark002_1K-JPG/Bark002_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark002_1K-JPG/Bark002_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee5a49dd3fab84bfa4e4e07dfbe293806de7dafdc5541d752809d329d0a20741
-size 2470186

--- a/src/app/public/textures/bark/Bark003_1K-JPG/Bark003_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark003_1K-JPG/Bark003_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:60351dd5bce5cc8d6be6288e207bd9be322c0ae6a834ff38e12914652cff132e
-size 554470

--- a/src/app/public/textures/bark/Bark003_1K-JPG/Bark003_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark003_1K-JPG/Bark003_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:388bd751e4bf7019468f9da77985e3b0bf720b504fe92415095d2f7dc6760fc6
-size 429168

--- a/src/app/public/textures/bark/Bark003_1K-JPG/Bark003_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark003_1K-JPG/Bark003_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f8f0cee1d93408e4c14af6bdc4419cc7428a7efd8e0e14648b9e98fec0578c4
-size 2570614

--- a/src/app/public/textures/bark/Bark004_1K-JPG/Bark004_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark004_1K-JPG/Bark004_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d039dfcfa807a2c4915d5505eb935a1a173da5dc35edf7827a516b8911b48648
-size 554184

--- a/src/app/public/textures/bark/Bark004_1K-JPG/Bark004_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark004_1K-JPG/Bark004_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3032a272c5eb7331678951f4c1508b2da6c5673e1cddc968d66a6189ccb139d
-size 373807

--- a/src/app/public/textures/bark/Bark004_1K-JPG/Bark004_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark004_1K-JPG/Bark004_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d14c5d8bf4b38c842d2ce845c377a3951068c0d8dd95e4d5878c7cd4e3436e73
-size 2369603

--- a/src/app/public/textures/bark/Bark006_1K-JPG/Bark006_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark006_1K-JPG/Bark006_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e068921883e9d03a68f732d660fd8dfb9d9b00f9d7e1a3fb832267bba9888b
-size 541386

--- a/src/app/public/textures/bark/Bark006_1K-JPG/Bark006_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark006_1K-JPG/Bark006_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:30b3455238ccd63857617a9b023ae52ecc5d3e6950b40c6e6c9d7bc95cce7315
-size 390693

--- a/src/app/public/textures/bark/Bark006_1K-JPG/Bark006_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark006_1K-JPG/Bark006_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0f2a4fdcb46e94be0f2ccd1c7e1fdf374cf900e627938ae36d997ac0f696d31
-size 2302212

--- a/src/app/public/textures/bark/Bark007_1K-JPG/Bark007_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark007_1K-JPG/Bark007_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2b5a1f0ca3291977ecf78e62cac78f86d24c146018fc97b3952e6461e6887e63
-size 659228

--- a/src/app/public/textures/bark/Bark007_1K-JPG/Bark007_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark007_1K-JPG/Bark007_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:46240d4f9a427f25ccbc18496a76f343621405953e440316c4ef5069677f748c
-size 527892

--- a/src/app/public/textures/bark/Bark007_1K-JPG/Bark007_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark007_1K-JPG/Bark007_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5d7f877a4d04b7abf7ec74a74a737726dd68912375953ffc748459ceb68d4ee
-size 2471328

--- a/src/app/public/textures/bark/Bark008_1K-JPG/Bark008_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark008_1K-JPG/Bark008_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3c76d414920916facd6945f83910618afc1c600dec678d45a8e4fca8156a47fa
-size 299783

--- a/src/app/public/textures/bark/Bark008_1K-JPG/Bark008_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark008_1K-JPG/Bark008_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91c3950c8c84f88f714f0d30daea8796a64c31ee68055e6fcc214d6539d3be61
-size 239875

--- a/src/app/public/textures/bark/Bark008_1K-JPG/Bark008_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark008_1K-JPG/Bark008_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:32c11f36e1f1f9d26cd362d118e5671135f74d144e03b11b46ccef7ded87c2c8
-size 1177751

--- a/src/app/public/textures/bark/Bark012_1K-JPG/Bark012_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark012_1K-JPG/Bark012_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4f695890ad517325cc00659e6e66fa9388ee6470d525b78476c643d6c4c1e3b7
-size 758060

--- a/src/app/public/textures/bark/Bark012_1K-JPG/Bark012_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark012_1K-JPG/Bark012_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba9f34d58b68e6fd5a0800ee497d3893e87d014b3afc6f4f644ec02b0f241dda
-size 598905

--- a/src/app/public/textures/bark/Bark012_1K-JPG/Bark012_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark012_1K-JPG/Bark012_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c6d2bbcadb69573175cf51b8a8813b03ee5e1a4321c1740f3827de9efb8c2762
-size 2450338

--- a/src/app/public/textures/bark/Bark013_1K-JPG/Bark013_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark013_1K-JPG/Bark013_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1e62297e1fb3a60c46d59b60ae15962466faf888fde8caaab000035c0cf79216
-size 705883

--- a/src/app/public/textures/bark/Bark013_1K-JPG/Bark013_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark013_1K-JPG/Bark013_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5253f7ba9c5707294dc4a33a5b3bfd7b50d9c4fbb007bb4f9642dcb190e777d4
-size 522502

--- a/src/app/public/textures/bark/Bark013_1K-JPG/Bark013_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark013_1K-JPG/Bark013_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:83457007f4739fd4dfe77f6d22a081aee1ba9266702f74ee082343883cd5c0e0
-size 2137901

--- a/src/app/public/textures/bark/Bark014_1K-JPG/Bark014_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark014_1K-JPG/Bark014_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:92ece37c217aa0609a02327a860520bfd3145cabe82bef1cf9fad601d3b86f15
-size 753753

--- a/src/app/public/textures/bark/Bark014_1K-JPG/Bark014_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark014_1K-JPG/Bark014_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0157cc50fd51efd0ce1d91a61c9e3da4f2ead0df026b04eefde7e79785968a69
-size 394989

--- a/src/app/public/textures/bark/Bark014_1K-JPG/Bark014_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark014_1K-JPG/Bark014_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5f8cdd6e3f30b4c4a6e287330b3875a9dbed11767c2f590c916053a9c5723d48
-size 1747079

--- a/src/app/public/textures/bark/Bark015_1K-JPG/Bark015_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark015_1K-JPG/Bark015_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f1f76bec73110050d943f42f4f51b636590239fce90aba0d3d81526c16672e78
-size 831667

--- a/src/app/public/textures/bark/Bark015_1K-JPG/Bark015_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark015_1K-JPG/Bark015_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d23c3178caae573e56c3d409c7571ee0865ed03e2d3372ea1861a21bd24447ae
-size 438076

--- a/src/app/public/textures/bark/Bark015_1K-JPG/Bark015_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark015_1K-JPG/Bark015_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c43be48cadd4f5e10275165190785183b5cc283e9bdc28f1404fb9bb333c1e02
-size 2176851

--- a/src/app/scene.js
+++ b/src/app/scene.js
@@ -70,9 +70,9 @@ export async function createScene(renderer) {
 
     const t = new Tree();
     t.position.set(r * Math.cos(theta), 0, r * Math.sin(theta));
-    loadPresetWithTextures(t, presets[index]);
+    loadPresetWithTextures(t, presets[index], false);
     t.options.seed = 10000 * Math.random();
-    t.generate();
+    t.generateLODs();
     t.castShadow = true;
     t.receiveShadow = true;
 

--- a/src/app/textures.js
+++ b/src/app/textures.js
@@ -94,11 +94,15 @@ export function applyTreeTextures(tree) {
  * the same step so the first generate sees the textures.
  * @param {import('@dgreenheck/ez-tree').Tree} tree
  * @param {string} name - key into TreePreset registry
+ * @param {boolean} generate - set false to skip the generate step when the
+ * caller will generate the tree itself (e.g. via generateLODs)
  */
-export function loadPresetWithTextures(tree, name) {
+export function loadPresetWithTextures(tree, name, generate = true) {
   const json = structuredClone(TreePreset[name]);
   if (!json) return;
   tree.options.copy(json);
   applyTreeTextures(tree);
-  tree.generate();
+  if (generate) {
+    tree.generate();
+  }
 }

--- a/src/app/textures.js
+++ b/src/app/textures.js
@@ -28,14 +28,19 @@ const textureLoader = new THREE.TextureLoader();
 const barkCache = new Map();
 const leafCache = new Map();
 
-function loadColor(url) {
-  const t = textureLoader.load(url);
+// The onError callbacks below matter: a texture whose file is missing keeps
+// an undefined image forever (the dev server masks the 404 by serving
+// index.html). That renders harmlessly but breaks GLTF export, so a failed
+// load must remove the map from the cache entirely.
+
+function loadColor(url, onError) {
+  const t = textureLoader.load(url, undefined, undefined, onError);
   t.colorSpace = THREE.SRGBColorSpace;
   return t;
 }
 
-function loadLinear(url) {
-  return textureLoader.load(url);
+function loadLinear(url, onError) {
+  return textureLoader.load(url, undefined, undefined, onError);
 }
 
 /**
@@ -49,12 +54,15 @@ export function getBarkMaps(type) {
 
   const dir = `${type}_1K-JPG`;
   const base = `/textures/bark/${dir}/${dir}`;
-  const maps = {
-    color: loadColor(`${base}_Color.jpg`),
-    ao: loadLinear(`${base}_AmbientOcclusion.jpg`),
-    normal: loadLinear(`${base}_NormalGL.jpg`),
-    roughness: loadLinear(`${base}_Roughness.jpg`),
+  const maps = {};
+  const drop = (key) => () => {
+    console.warn(`Missing bark texture: ${base}_… (${key}); skipping this map.`);
+    maps[key] = null;
   };
+  maps.color = loadColor(`${base}_Color.jpg`, drop('color'));
+  maps.ao = loadLinear(`${base}_AmbientOcclusion.jpg`, drop('ao'));
+  maps.normal = loadLinear(`${base}_NormalGL.jpg`, drop('normal'));
+  maps.roughness = loadLinear(`${base}_Roughness.jpg`, drop('roughness'));
   barkCache.set(type, maps);
   return maps;
 }
@@ -66,7 +74,10 @@ export function getBarkMaps(type) {
  */
 export function getLeafMap(type) {
   if (leafCache.has(type)) return leafCache.get(type);
-  const texture = loadColor(`/textures/leaves/${type}.png`);
+  const texture = loadColor(`/textures/leaves/${type}.png`, () => {
+    console.warn(`Missing leaf texture: /textures/leaves/${type}.png; skipping.`);
+    leafCache.set(type, null);
+  });
   texture.premultiplyAlpha = true;
   leafCache.set(type, texture);
   return texture;

--- a/src/app/textures.js
+++ b/src/app/textures.js
@@ -46,7 +46,7 @@ function loadLinear(url, onError) {
 /**
  * Returns a cached set of THREE.Texture maps for the given bark type.
  * @param {string} type - one of BarkType values
- * @returns {{ color: THREE.Texture, ao: THREE.Texture, normal: THREE.Texture, roughness: THREE.Texture } | null}
+ * @returns {{ color: THREE.Texture, normal: THREE.Texture, roughness: THREE.Texture } | null}
  */
 export function getBarkMaps(type) {
   if (!BarkType[type]) return null;
@@ -60,7 +60,6 @@ export function getBarkMaps(type) {
     maps[key] = null;
   };
   maps.color = loadColor(`${base}_Color.jpg`, drop('color'));
-  maps.ao = loadLinear(`${base}_AmbientOcclusion.jpg`, drop('ao'));
   maps.normal = loadLinear(`${base}_NormalGL.jpg`, drop('normal'));
   maps.roughness = loadLinear(`${base}_Roughness.jpg`, drop('roughness'));
   barkCache.set(type, maps);
@@ -93,7 +92,6 @@ export function applyTreeTextures(tree) {
   const barkMaps = getBarkMaps(tree.options.bark.type);
   if (barkMaps) {
     tree.options.bark.maps.color = barkMaps.color;
-    tree.options.bark.maps.ao = barkMaps.ao;
     tree.options.bark.maps.normal = barkMaps.normal;
     tree.options.bark.maps.roughness = barkMaps.roughness;
   }

--- a/src/app/ui.js
+++ b/src/app/ui.js
@@ -1054,13 +1054,39 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
 
   const exportModelsSection = createSection('Export Models', 'cubeTransparent', true);
 
+  /**
+   * GLTFExporter aborts on textures whose image never loaded (e.g. the
+   * texture file is missing on disk). Rendering tolerates them, so strip
+   * them from the materials for the duration of an export and restore after.
+   * @param {THREE.Object3D} root
+   * @returns {() => void} restore function
+   */
+  function stripBrokenTextures(root) {
+    const restores = [];
+    root.traverse((o) => {
+      const materials = Array.isArray(o.material) ? o.material : o.material ? [o.material] : [];
+      for (const material of materials) {
+        for (const key of ['map', 'aoMap', 'normalMap', 'roughnessMap', 'metalnessMap']) {
+          const texture = material[key];
+          if (texture?.isTexture && !texture.image) {
+            restores.push(() => { material[key] = texture; });
+            material[key] = null;
+          }
+        }
+      }
+    });
+    return () => restores.forEach((restore) => restore());
+  }
+
   const exportGlbBtn = createButton('Export GLB (Full Detail)', 'download', () => {
     // Export at full detail regardless of the active LOD preview
     const restoreLevel = previewLevel;
     if (restoreLevel !== 0) {
       setPreviewLevel(0);
     }
-    const restorePreview = () => {
+    const restoreTextures = stripBrokenTextures(tree);
+    const restore = () => {
+      restoreTextures();
       if (restoreLevel !== 0) {
         setPreviewLevel(restoreLevel);
       }
@@ -1074,11 +1100,11 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
         link.href = url;
         link.download = 'tree.glb';
         link.click();
-        restorePreview();
+        restore();
       },
       (err) => {
         console.error(err);
-        restorePreview();
+        restore();
       },
       { binary: true }
     );
@@ -1086,6 +1112,7 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
   exportModelsSection.add(exportGlbBtn);
 
   const exportLodsBtn = createButton('Export LODs (ZIP)', 'archive', async () => {
+    const restoreTextures = stripBrokenTextures(tree);
     try {
       const files = {};
       for (let i = 0; i < Tree.defaultLODLevels.length; i++) {
@@ -1116,6 +1143,8 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
       link.click();
     } catch (err) {
       console.error(err);
+    } finally {
+      restoreTextures();
     }
   });
   exportModelsSection.add(exportLodsBtn);

--- a/src/app/ui.js
+++ b/src/app/ui.js
@@ -1119,21 +1119,23 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
         const { detail } = Tree.defaultLODLevels[i];
         const { branches, leaves } = tree.createGeometry(detail ?? {});
 
-        const branchesMesh = new THREE.Mesh(branches, tree.branchesMesh.material);
-        branchesMesh.name = `Branches_LOD${i}`;
-        const leavesMesh = new THREE.Mesh(leaves, tree.leavesMesh.material);
-        leavesMesh.name = `Leaves_LOD${i}`;
-        const group = new THREE.Group();
-        group.name = `Tree_LOD${i}`;
-        group.add(branchesMesh, leavesMesh);
+        try {
+          const branchesMesh = new THREE.Mesh(branches, tree.branchesMesh.material);
+          branchesMesh.name = `Branches_LOD${i}`;
+          const leavesMesh = new THREE.Mesh(leaves, tree.leavesMesh.material);
+          leavesMesh.name = `Leaves_LOD${i}`;
+          const group = new THREE.Group();
+          group.name = `Tree_LOD${i}`;
+          group.add(branchesMesh, leavesMesh);
 
-        const glb = await new Promise((resolve, reject) =>
-          exporter.parse(group, resolve, reject, { binary: true }),
-        );
-        files[`tree_LOD${i}.glb`] = new Uint8Array(glb);
-
-        branches.dispose();
-        leaves.dispose();
+          const glb = await new Promise((resolve, reject) =>
+            exporter.parse(group, resolve, reject, { binary: true }),
+          );
+          files[`tree_LOD${i}.glb`] = new Uint8Array(glb);
+        } finally {
+          branches.dispose();
+          leaves.dispose();
+        }
       }
 
       const blob = new Blob([zipSync(files)], { type: 'application/zip' });

--- a/src/app/ui.js
+++ b/src/app/ui.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { GLTFExporter } from 'three/addons/exporters/GLTFExporter.js';
+import { zipSync } from 'three/addons/libs/fflate.module.js';
 import { Billboard, TreePreset, Tree, TreeType } from '@dgreenheck/ez-tree';
 import { BarkType, LeafType, applyTreeTextures, loadPresetWithTextures } from './textures';
 import { Environment } from './environment';
@@ -460,12 +461,83 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
   scrollArea.appendChild(exportTab);
 
   // ============================================================================
+  // Stats Overlay (viewport HUD) with LOD preview switching
+  // ============================================================================
+
+  // The hero tree always generates at full detail; the LOD buttons re-mesh
+  // its geometry at a chosen level via createGeometry() so it can be
+  // inspected at any camera distance without THREE.LOD auto-switching.
+  let previewLevel = 0;
+
+  const statsOverlay = document.createElement('div');
+  statsOverlay.id = 'stats-overlay';
+  statsOverlay.innerHTML = `
+    <div class="stats-counts">
+      <div class="stats-stat">
+        <span class="stats-value" data-stat="triangles">0</span>
+        <span class="stats-label">triangles</span>
+      </div>
+      <div class="stats-stat">
+        <span class="stats-value" data-stat="vertices">0</span>
+        <span class="stats-label">vertices</span>
+      </div>
+    </div>
+    <div class="lod-switcher"></div>
+  `;
+  container.appendChild(statsOverlay);
+
+  const statsTriangles = statsOverlay.querySelector('[data-stat="triangles"]');
+  const statsVertices = statsOverlay.querySelector('[data-stat="vertices"]');
+
+  const lodSwitcher = statsOverlay.querySelector('.lod-switcher');
+  const lodButtons = Tree.defaultLODLevels.map((level, i) => {
+    const btn = document.createElement('button');
+    btn.className = 'lod-button' + (i === 0 ? ' active' : '');
+    btn.textContent = i === 0 ? 'Full' : `LOD${i}`;
+    btn.title = i === 0
+      ? 'Full detail'
+      : `Preview detail level ${i} (switches at ${level.distance} units)`;
+    btn.addEventListener('click', () => setPreviewLevel(i));
+    lodSwitcher.appendChild(btn);
+    return btn;
+  });
+
+  function applyLODPreview() {
+    const detail = Tree.defaultLODLevels[previewLevel]?.detail ?? {};
+    const { branches, leaves } = tree.createGeometry(detail);
+    tree.branchesMesh.geometry.dispose();
+    tree.branchesMesh.geometry = branches;
+    tree.leavesMesh.geometry.dispose();
+    tree.leavesMesh.geometry = leaves;
+  }
+
+  function setPreviewLevel(level) {
+    previewLevel = level;
+    lodButtons.forEach((b, i) => b.classList.toggle('active', i === level));
+    applyLODPreview();
+    updateInfoDisplays();
+  }
+
+  /** Vertex/triangle counts of the geometry currently on screen */
+  function displayedCounts() {
+    const gb = tree.branchesMesh.geometry;
+    const gl = tree.leavesMesh.geometry;
+    return {
+      vertices: (gb.attributes.position?.count ?? 0) + (gl.attributes.position?.count ?? 0),
+      triangles: ((gb.index?.count ?? 0) + (gl.index?.count ?? 0)) / 3,
+    };
+  }
+
+  // ============================================================================
   // Parameters Tab Content
   // ============================================================================
 
   const onChange = () => {
     applyTreeTextures(tree);
     tree.generate();
+    if (previewLevel > 0) {
+      applyLODPreview();
+    }
     tree.traverse((o) => {
       if (o.material) {
         o.material.needsUpdate = true;
@@ -483,6 +555,9 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
     initialPreset,
     (val) => {
       loadPresetWithTextures(tree, val);
+      if (previewLevel > 0) {
+        applyLODPreview();
+      }
       refreshAllControls();
     }
   );
@@ -947,8 +1022,11 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
   parametersTab.appendChild(infoSection.element);
 
   function updateInfoDisplays() {
-    vertexDisplay.setValue(tree.vertexCount);
-    triangleDisplay.setValue(tree.triangleCount);
+    const { vertices, triangles } = displayedCounts();
+    vertexDisplay.setValue(vertices);
+    triangleDisplay.setValue(triangles);
+    statsVertices.textContent = Math.round(vertices).toLocaleString();
+    statsTriangles.textContent = Math.round(triangles).toLocaleString();
   }
 
   // ============================================================================
@@ -976,7 +1054,17 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
 
   const exportModelsSection = createSection('Export Models', 'cubeTransparent', true);
 
-  const exportGlbBtn = createButton('Export GLB', 'download', () => {
+  const exportGlbBtn = createButton('Export GLB (Full Detail)', 'download', () => {
+    // Export at full detail regardless of the active LOD preview
+    const restoreLevel = previewLevel;
+    if (restoreLevel !== 0) {
+      setPreviewLevel(0);
+    }
+    const restorePreview = () => {
+      if (restoreLevel !== 0) {
+        setPreviewLevel(restoreLevel);
+      }
+    };
     exporter.parse(
       tree,
       (glb) => {
@@ -986,14 +1074,51 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
         link.href = url;
         link.download = 'tree.glb';
         link.click();
+        restorePreview();
       },
       (err) => {
         console.error(err);
+        restorePreview();
       },
       { binary: true }
     );
   });
   exportModelsSection.add(exportGlbBtn);
+
+  const exportLodsBtn = createButton('Export LODs (ZIP)', 'archive', async () => {
+    try {
+      const files = {};
+      for (let i = 0; i < Tree.defaultLODLevels.length; i++) {
+        const { detail } = Tree.defaultLODLevels[i];
+        const { branches, leaves } = tree.createGeometry(detail ?? {});
+
+        const branchesMesh = new THREE.Mesh(branches, tree.branchesMesh.material);
+        branchesMesh.name = `Branches_LOD${i}`;
+        const leavesMesh = new THREE.Mesh(leaves, tree.leavesMesh.material);
+        leavesMesh.name = `Leaves_LOD${i}`;
+        const group = new THREE.Group();
+        group.name = `Tree_LOD${i}`;
+        group.add(branchesMesh, leavesMesh);
+
+        const glb = await new Promise((resolve, reject) =>
+          exporter.parse(group, resolve, reject, { binary: true }),
+        );
+        files[`tree_LOD${i}.glb`] = new Uint8Array(glb);
+
+        branches.dispose();
+        leaves.dispose();
+      }
+
+      const blob = new Blob([zipSync(files)], { type: 'application/zip' });
+      const link = document.getElementById('downloadLink');
+      link.href = URL.createObjectURL(blob);
+      link.download = 'tree_lods.zip';
+      link.click();
+    } catch (err) {
+      console.error(err);
+    }
+  });
+  exportModelsSection.add(exportLodsBtn);
 
   const exportPngBtn = createButton('Export PNG', 'photo', () => {
     renderer.setClearColor(0, 0);
@@ -1058,6 +1183,9 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
         try {
           tree.options = JSON.parse(e.target.result);
           tree.generate();
+          if (previewLevel > 0) {
+            applyLODPreview();
+          }
           refreshAllControls();
         } catch (error) {
           console.error('Error parsing JSON:', error);
@@ -1077,6 +1205,9 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
     controls.forEach(({ update }) => update());
     updateInfoDisplays();
   }
+
+  // Initialize the stats overlay with the current tree's counts
+  updateInfoDisplays();
 
   // Mobile expand/collapse functionality
   setupMobileToggle(panel, header);

--- a/src/lib/tree.js
+++ b/src/lib/tree.js
@@ -31,6 +31,8 @@ export class Tree extends THREE.Group {
     this.branchesMesh = new THREE.Mesh();
     this.leavesMesh = new THREE.Mesh();
     this.trellisMesh = null;
+    this.lod = null;
+    this.skeleton = null;
     this.add(this.branchesMesh);
     this.add(this.leavesMesh);
     this.options = options;
@@ -62,23 +64,184 @@ export class Tree extends THREE.Group {
   }
 
   /**
+   * @typedef {Object} LODDetail
+   * @property {number} [sectionStride=1] Sample every Nth section ring; the
+   *   first and last rings are always kept so branch endpoints stay put
+   * @property {number} [segmentFactor=1] Radial segment multiplier;
+   *   segments = max(3, round(segmentCount * segmentFactor))
+   * @property {number} [leafStride=1] Keep every Nth leaf
+   * @property {number} [leafScale=1] Size multiplier for the kept leaves,
+   *   typically 1/sqrt(kept fraction) to preserve canopy coverage
+   * @property {string} [billboard] Billboard mode override for this level
+   *   ('single' or 'double'); defaults to options.leaves.billboard
+   */
+
+  /**
+   * @typedef {Object} LODLevel
+   * @property {number} distance Camera distance at which this level activates
+   * @property {number} [hysteresis] Switch hysteresis as a fraction of distance
+   * @property {LODDetail} [detail] Meshing detail for this level
+   */
+
+  /**
+   * Default levels for generateLODs(). LOD1 is roughly 40% of the full
+   * triangle count, LOD2 roughly 20%.
+   * @type {LODLevel[]}
+   */
+  static defaultLODLevels = [
+    { distance: 0, detail: {} },
+    {
+      distance: 100,
+      hysteresis: 0.05,
+      detail: {
+        sectionStride: 3,
+        segmentFactor: 0.75,
+        leafStride: 2,
+        // Slightly under the area-preserving sqrt(2): individual leaves are
+        // still resolvable at this distance, so a full compensation reads as
+        // "bigger leaves" rather than "same canopy".
+        leafScale: 1.25,
+      },
+    },
+    {
+      distance: 250,
+      hysteresis: 0.05,
+      detail: {
+        sectionStride: 6,
+        segmentFactor: 0.4,
+        leafStride: 2,
+        // Deliberately under-compensated: full coverage compensation for the
+        // thinning + single billboard would need 2x scale, which reads as
+        // balloon leaves. A slightly sparser canopy with natural-size leaves
+        // looks better at this distance (fogged, 250+ units in the demo).
+        leafScale: 1.3,
+        billboard: Billboard.Single,
+      },
+    },
+  ];
+
+  /**
    * Generate a new tree
    */
   generate() {
-    // Clean up old geometry
-    this.branches = {
-      verts: [],
-      normals: [],
-      indices: [],
-      uvs: [],
-      windFactor: []
-    };
+    this.#clearLOD();
+    this.#generateSkeleton();
 
-    this.leaves = {
-      verts: [],
-      normals: [],
-      indices: [],
-      uvs: [],
+    const buffers = this.#meshSkeleton();
+    this.branches = buffers.branches;
+    this.leaves = buffers.leaves;
+
+    this.createBranchesGeometry();
+    this.createLeavesGeometry();
+    this.createTrellis();
+  }
+
+  /**
+   * Generates the tree as a set of levels of detail hosted in a THREE.LOD
+   * object inside this group. The renderer switches levels automatically
+   * based on camera distance. All levels share one bark and one leaf
+   * material, so update() animates wind at every level.
+   * @param {LODLevel[]} levels Ordered near-to-far level descriptors
+   */
+  generateLODs(levels = Tree.defaultLODLevels) {
+    this.#clearLOD();
+    this.#generateSkeleton();
+
+    const barkMaterial = this.#createBarkMaterial();
+    const leafMaterial = this.#createLeafMaterial();
+
+    this.lod = new THREE.LOD();
+    this.lod.name = 'TreeLOD';
+
+    levels.forEach((level, index) => {
+      const buffers = this.#meshSkeleton(level.detail ?? {});
+
+      let branchesMesh, leavesMesh;
+      if (index === 0) {
+        // Reuse the existing meshes for the closest level so update(),
+        // traversal and the vertex/triangle count getters keep working.
+        this.branches = buffers.branches;
+        this.leaves = buffers.leaves;
+        branchesMesh = this.branchesMesh;
+        leavesMesh = this.leavesMesh;
+        branchesMesh.geometry.dispose();
+        branchesMesh.material.dispose();
+        leavesMesh.geometry.dispose();
+        leavesMesh.material.dispose();
+      } else {
+        branchesMesh = new THREE.Mesh();
+        leavesMesh = new THREE.Mesh();
+      }
+
+      branchesMesh.geometry = this.#buildBufferGeometry(buffers.branches);
+      branchesMesh.material = barkMaterial;
+      leavesMesh.geometry = this.#buildBufferGeometry(buffers.leaves);
+      leavesMesh.material = leafMaterial;
+
+      for (const mesh of [branchesMesh, leavesMesh]) {
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+      }
+
+      const group = new THREE.Group();
+      group.add(branchesMesh, leavesMesh);
+      this.lod.addLevel(group, level.distance ?? 0, level.hysteresis ?? 0);
+    });
+
+    this.add(this.lod);
+    this.createTrellis();
+  }
+
+  /**
+   * Builds branch and leaf geometry at the given detail level without
+   * modifying the tree's own meshes. Useful for external instancing or
+   * custom LOD systems. Reuses the current skeleton, generating one first
+   * if none exists.
+   * @param {LODDetail} detail
+   * @returns {{ branches: THREE.BufferGeometry, leaves: THREE.BufferGeometry }}
+   */
+  createGeometry(detail = {}) {
+    if (!this.skeleton) {
+      this.#generateSkeleton();
+    }
+    const buffers = this.#meshSkeleton(detail);
+    return {
+      branches: this.#buildBufferGeometry(buffers.branches),
+      leaves: this.#buildBufferGeometry(buffers.leaves),
+    };
+  }
+
+  /**
+   * Tears down any LOD state and restores the flat branches/leaves meshes
+   * as direct children, so generate() behaves as if LODs never existed.
+   */
+  #clearLOD() {
+    if (!this.lod) return;
+
+    this.lod.levels.forEach((level, index) => {
+      // Level 0 reuses branchesMesh/leavesMesh; their geometry and the
+      // shared materials are disposed by whichever generate path runs next.
+      if (index === 0) return;
+      for (const mesh of level.object.children) {
+        mesh.geometry.dispose();
+      }
+    });
+
+    this.remove(this.lod);
+    this.lod = null;
+    this.add(this.branchesMesh, this.leavesMesh);
+  }
+
+  /**
+   * Grows the tree skeleton: the section frames of every branch and the
+   * placement of every leaf. All RNG consumption happens here, so any
+   * number of meshing passes can run against one skeleton without changing
+   * the tree's shape.
+   */
+  #generateSkeleton() {
+    this.skeleton = {
+      branches: [],
+      leaves: [],
     };
 
     this.rng = new RNG(this.options.seed);
@@ -98,23 +261,56 @@ export class Tree extends THREE.Group {
 
     while (this.branchQueue.length > 0) {
       const branch = this.branchQueue.shift();
-      this.generateBranch(branch);
+      this.#growBranch(branch);
     }
-
-    this.createBranchesGeometry();
-    this.createLeavesGeometry();
-    this.createTrellis();
   }
 
   /**
-   * Generates a new branch
+   * Meshes the current skeleton into geometry buffers at the given detail.
+   * Consumes no RNG, so it can run repeatedly with different detail specs.
+   * @param {LODDetail} detail
+   */
+  #meshSkeleton(detail = {}) {
+    const sectionStride = Math.max(1, Math.floor(detail.sectionStride ?? 1));
+    const segmentFactor = detail.segmentFactor ?? 1;
+    const leafStride = Math.max(1, Math.floor(detail.leafStride ?? 1));
+    const leafScale = detail.leafScale ?? 1;
+    const billboard = detail.billboard ?? this.options.leaves.billboard;
+
+    const branches = {
+      verts: [],
+      normals: [],
+      indices: [],
+      uvs: [],
+      windFactor: []
+    };
+
+    const leaves = {
+      verts: [],
+      normals: [],
+      indices: [],
+      uvs: [],
+    };
+
+    for (const skeletonBranch of this.skeleton.branches) {
+      this.#meshBranch(branches, skeletonBranch, sectionStride, segmentFactor);
+    }
+
+    for (let i = 0; i < this.skeleton.leaves.length; i += leafStride) {
+      this.#meshLeaf(leaves, this.skeleton.leaves[i], leafScale, billboard);
+    }
+
+    return { branches, leaves };
+  }
+
+  /**
+   * Grows a branch's skeleton, queueing child branches and recording leaf
+   * placements. Consumes RNG in the exact order of the original interleaved
+   * generator so seeds keep producing identical trees.
    * @param {Branch} branch
    * @returns
    */
-  generateBranch(branch) {
-    // Used later for geometry index generation
-    const indexOffset = this.branches.verts.length / 3;
-
+  #growBranch(branch) {
     let sectionOrientation = branch.orientation.clone();
     let sectionOrigin = branch.origin.clone();
     let sectionLength =
@@ -125,15 +321,6 @@ export class Tree extends THREE.Group {
     // This information is used for generating child branches after the branch
     // geometry has been constructed
     let sections = [];
-
-    // Number of texture wraps around the branch's circumference. Scaling with
-    // branch.radius keeps bark feature size roughly consistent across thick
-    // trunks and thin twigs. Held constant for the whole branch so tapered
-    // sections share a wrap count and don't twist the texture longitudinally.
-    const wrapsX = Math.max(
-      1,
-      Math.round(branch.radius * this.options.bark.textureScale.x),
-    );
 
     for (let i = 0; i <= branch.sectionCount; i++) {
       let sectionRadius = branch.radius;
@@ -151,41 +338,6 @@ export class Tree extends THREE.Group {
         // Evergreens do not have a terminal branch so they have a taper of 1
         sectionRadius *= 1 - (i / branch.sectionCount);
       }
-
-      // Create the segments that make up this section.
-      let first;
-      for (let j = 0; j < branch.segmentCount; j++) {
-        let angle = (2.0 * Math.PI * j) / branch.segmentCount;
-
-        // Create the segment vertex
-        const vertex = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle))
-          .multiplyScalar(sectionRadius)
-          .applyEuler(sectionOrientation)
-          .add(sectionOrigin);
-
-        const normal = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle))
-          .applyEuler(sectionOrientation)
-          .normalize();
-
-        const uv = new THREE.Vector2(
-          (j / branch.segmentCount) * wrapsX,
-          (i % 2 === 0) ? 0 : 1,
-        );
-
-        this.branches.verts.push(...Object.values(vertex));
-        this.branches.normals.push(...Object.values(normal));
-        this.branches.uvs.push(...Object.values(uv));
-
-        if (j === 0) {
-          first = { vertex, normal, uv };
-        }
-      }
-
-      // Duplicate the first vertex so there is continuity in the UV mapping.
-      // u=wrapsX maps to the same texel as u=0 since wrapsX is an integer.
-      this.branches.verts.push(...Object.values(first.vertex));
-      this.branches.normals.push(...Object.values(first.normal));
-      this.branches.uvs.push(wrapsX, first.uv.y);
 
       // Use this information later on when generating child branches
       sections.push({
@@ -255,7 +407,11 @@ export class Tree extends THREE.Group {
       sectionOrientation.setFromQuaternion(qSection);
     }
 
-    this.generateBranchIndices(indexOffset, branch);
+    this.skeleton.branches.push({
+      sections,
+      segmentCount: branch.segmentCount,
+      baseRadius: branch.radius,
+    });
 
     // Deciduous trees have a terminal branch that grows out of the
     // end of the parent branch
@@ -277,7 +433,7 @@ export class Tree extends THREE.Group {
           ),
         );
       } else {
-        this.generateLeaf(lastSection.origin, lastSection.orientation);
+        this.#recordLeaf(lastSection.origin, lastSection.orientation);
       }
     }
 
@@ -457,26 +613,46 @@ export class Tree extends THREE.Group {
         q3.multiply(q2.multiply(q1)),
       );
 
-      this.generateLeaf(leafOrigin, leafOrientation);
+      this.#recordLeaf(leafOrigin, leafOrientation);
     }
   }
 
   /**
-  * Generates a leaves
-  * @param {THREE.Vector3} origin The starting point of the branch
-  * @param {THREE.Euler} orientation The starting orientation of the branch
+  * Records a leaf placement in the skeleton. The size variance is sampled
+  * here so the meshing passes stay RNG-free.
+  * @param {THREE.Vector3} origin The starting point of the leaf
+  * @param {THREE.Euler} orientation The orientation of the leaf
   */
-  generateLeaf(origin, orientation) {
-    let i = this.leaves.verts.length / 3;
-
-    // Width and length of the leaf quad
-    let leafSize =
+  #recordLeaf(origin, orientation) {
+    const size =
       this.options.leaves.size *
       (1 +
         this.rng.random(
           this.options.leaves.sizeVariance,
           -this.options.leaves.sizeVariance,
         ));
+
+    this.skeleton.leaves.push({
+      origin: origin.clone(),
+      orientation: orientation.clone(),
+      size,
+    });
+  }
+
+  /**
+  * Emits the quad geometry for one skeleton leaf into the buffers
+  * @param {{verts: number[], normals: number[], indices: number[], uvs: number[]}} buffers
+  * @param {{origin: THREE.Vector3, orientation: THREE.Euler, size: number}} leaf
+  * @param {number} scale Size multiplier for this detail level
+  * @param {string} billboard Billboard mode for this detail level
+  */
+  #meshLeaf(buffers, leaf, scale, billboard) {
+    let i = buffers.verts.length / 3;
+
+    const { origin, orientation } = leaf;
+
+    // Width and length of the leaf quad
+    const leafSize = leaf.size * scale;
 
     const W = leafSize;
     const L = leafSize;
@@ -495,7 +671,7 @@ export class Tree extends THREE.Group {
           .add(origin),
       );
 
-      this.leaves.verts.push(
+      buffers.verts.push(
         v[0].x,
         v[0].y,
         v[0].z,
@@ -520,7 +696,7 @@ export class Tree extends THREE.Group {
       let n3 = roundedNormals ? new THREE.Vector3().copy(n).add(v[2]).sub(origin).normalize() : n;
       let n4 = roundedNormals ? new THREE.Vector3().copy(n).add(v[3]).sub(origin).normalize() : n;
 
-      this.leaves.normals.push(
+      buffers.normals.push(
         n1.x,
         n1.y,
         n1.z,
@@ -534,13 +710,13 @@ export class Tree extends THREE.Group {
         n4.y,
         n4.z,
       );
-      this.leaves.uvs.push(0, 1, 0, 0, 1, 0, 1, 1);
-      this.leaves.indices.push(i, i + 1, i + 2, i, i + 2, i + 3);
+      buffers.uvs.push(0, 1, 0, 0, 1, 0, 1, 1);
+      buffers.indices.push(i, i + 1, i + 2, i, i + 2, i + 3);
       i += 4;
     };
 
     createLeaf(0);
-    if (this.options.leaves.billboard === Billboard.Double) {
+    if (billboard === Billboard.Double) {
       createLeaf(Math.PI / 2);
     }
   }
@@ -561,48 +737,130 @@ export class Tree extends THREE.Group {
   }
 
   /**
-   * Generates the indices for branch geometry
-   * @param {Branch} branch
+   * Emits the ring geometry and indices for one skeleton branch
+   * @param {{verts: number[], normals: number[], indices: number[], uvs: number[]}} buffers
+   * @param {{sections: {origin: THREE.Vector3, orientation: THREE.Euler, radius: number}[], segmentCount: number, baseRadius: number}} skeletonBranch
+   * @param {number} sectionStride Sample every Nth section ring
+   * @param {number} segmentFactor Radial segment multiplier
    */
-  generateBranchIndices(indexOffset, branch) {
-    // Build geometry each section of the branch (cylinder without end caps)
+  #meshBranch(buffers, skeletonBranch, sectionStride, segmentFactor) {
+    const { sections, segmentCount, baseRadius } = skeletonBranch;
+
+    // Terminal branches inherit the parent's segmentCount, so parent and
+    // child resolve to the same reduced count and junctions stay sealed.
+    const segments = Math.max(3, Math.round(segmentCount * segmentFactor));
+
+    // Number of texture wraps around the branch's circumference. Scaling with
+    // the branch's base radius keeps bark feature size roughly consistent
+    // across thick trunks and thin twigs. Held constant for the whole branch
+    // so tapered sections share a wrap count and don't twist the texture
+    // longitudinally.
+    const wrapsX = Math.max(
+      1,
+      Math.round(baseRadius * this.options.bark.textureScale.x),
+    );
+
+    // Sample every Nth ring, always keeping the first and last so branch
+    // endpoints (and parent/child junctions) stay put across detail levels.
+    const sampled = [];
+    for (let i = 0; i < sections.length; i += sectionStride) {
+      sampled.push(sections[i]);
+    }
+    if ((sections.length - 1) % sectionStride !== 0) {
+      sampled.push(sections[sections.length - 1]);
+    }
+
+    // Used later for geometry index generation
+    const indexOffset = buffers.verts.length / 3;
+
+    for (let k = 0; k < sampled.length; k++) {
+      const section = sampled[k];
+
+      // Create the segments that make up this section.
+      let first;
+      for (let j = 0; j < segments; j++) {
+        let angle = (2.0 * Math.PI * j) / segments;
+
+        // Create the segment vertex
+        const vertex = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle))
+          .multiplyScalar(section.radius)
+          .applyEuler(section.orientation)
+          .add(section.origin);
+
+        const normal = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle))
+          .applyEuler(section.orientation)
+          .normalize();
+
+        // uv.y alternates by sampled ring position rather than original
+        // section index, so section skipping keeps the 0/1 tiling pattern.
+        const uv = new THREE.Vector2(
+          (j / segments) * wrapsX,
+          (k % 2 === 0) ? 0 : 1,
+        );
+
+        buffers.verts.push(...Object.values(vertex));
+        buffers.normals.push(...Object.values(normal));
+        buffers.uvs.push(...Object.values(uv));
+
+        if (j === 0) {
+          first = { vertex, normal, uv };
+        }
+      }
+
+      // Duplicate the first vertex so there is continuity in the UV mapping.
+      // u=wrapsX maps to the same texel as u=0 since wrapsX is an integer.
+      buffers.verts.push(...Object.values(first.vertex));
+      buffers.normals.push(...Object.values(first.normal));
+      buffers.uvs.push(wrapsX, first.uv.y);
+    }
+
+    // Build geometry for each section of the branch (cylinder without end caps)
     let v1, v2, v3, v4;
-    const N = branch.segmentCount + 1;
-    for (let i = 0; i < branch.sectionCount; i++) {
+    const N = segments + 1;
+    for (let i = 0; i < sampled.length - 1; i++) {
       // Build the quad for each segment of the section
-      for (let j = 0; j < branch.segmentCount; j++) {
+      for (let j = 0; j < segments; j++) {
         v1 = indexOffset + i * N + j;
         // The last segment wraps around back to the starting segment, so omit j + 1 term
         v2 = indexOffset + i * N + (j + 1);
         v3 = v1 + N;
         v4 = v2 + N;
-        this.branches.indices.push(v1, v3, v2, v2, v3, v4);
+        buffers.indices.push(v1, v3, v2, v2, v3, v4);
       }
     }
   }
 
   /**
-   * Generates the geometry for the branches
+   * Builds a BufferGeometry from raw attribute buffers
+   * @param {{verts: number[], normals: number[], indices: number[], uvs: number[]}} buffers
+   * @returns {THREE.BufferGeometry}
    */
-  createBranchesGeometry() {
+  #buildBufferGeometry(buffers) {
     const g = new THREE.BufferGeometry();
     g.setAttribute(
       'position',
-      new THREE.BufferAttribute(new Float32Array(this.branches.verts), 3),
+      new THREE.BufferAttribute(new Float32Array(buffers.verts), 3),
     );
     g.setAttribute(
       'normal',
-      new THREE.BufferAttribute(new Float32Array(this.branches.normals), 3),
+      new THREE.BufferAttribute(new Float32Array(buffers.normals), 3),
     );
     g.setAttribute(
       'uv',
-      new THREE.BufferAttribute(new Float32Array(this.branches.uvs), 2),
+      new THREE.BufferAttribute(new Float32Array(buffers.uvs), 2),
     );
     g.setIndex(
-      new THREE.BufferAttribute(new Uint16Array(this.branches.indices), 1),
+      new THREE.BufferAttribute(new Uint16Array(buffers.indices), 1),
     );
     g.computeBoundingSphere();
+    return g;
+  }
 
+  /**
+   * Creates the bark material from the current options
+   * @returns {THREE.MeshPhongMaterial}
+   */
+  #createBarkMaterial() {
     const mat = new THREE.MeshPhongMaterial({
       name: 'branches',
       flatShading: this.options.bark.flatShading,
@@ -610,7 +868,7 @@ export class Tree extends THREE.Group {
     });
 
     if (this.options.bark.textured) {
-      // textureScale.x is baked into UVs in generateBranch (wrapsX), so only
+      // textureScale.x is baked into UVs during meshing (wrapsX), so only
       // the Y axis needs runtime scaling on the texture itself.
       const scale = this.options.bark.textureScale;
       const maps = this.options.bark.maps;
@@ -628,37 +886,27 @@ export class Tree extends THREE.Group {
       if (maps.roughness) mat.roughnessMap = apply(maps.roughness);
     }
 
+    return mat;
+  }
+
+  /**
+   * Generates the geometry for the branches
+   */
+  createBranchesGeometry() {
     this.branchesMesh.geometry.dispose();
-    this.branchesMesh.geometry = g;
+    this.branchesMesh.geometry = this.#buildBufferGeometry(this.branches);
     this.branchesMesh.material.dispose();
-    this.branchesMesh.material = mat;
+    this.branchesMesh.material = this.#createBarkMaterial();
     this.branchesMesh.castShadow = true;
     this.branchesMesh.receiveShadow = true;
   }
 
   /**
-   * Generates the geometry for the leaves
+   * Creates the leaf material, including the wind sway vertex shader, from
+   * the current options
+   * @returns {THREE.MeshPhongMaterial}
    */
-  createLeavesGeometry() {
-    const g = new THREE.BufferGeometry();
-    g.setAttribute(
-      'position',
-      new THREE.BufferAttribute(new Float32Array(this.leaves.verts), 3),
-    );
-    g.setAttribute(
-      'uv',
-      new THREE.BufferAttribute(new Float32Array(this.leaves.uvs), 2),
-    );
-    g.setIndex(
-      new THREE.BufferAttribute(new Uint16Array(this.leaves.indices), 1),
-    );
-    g.setAttribute(
-      'normal',
-      new THREE.BufferAttribute(new Float32Array(this.leaves.normals), 3),
-    );
-
-    g.computeBoundingSphere();
-
+  #createLeafMaterial() {
     const mat = new THREE.MeshPhongMaterial({
       name: 'leaves',
       map: this.options.leaves.map ?? null,
@@ -813,12 +1061,17 @@ export class Tree extends THREE.Group {
       mat.userData.shader = shader;
     };
 
+    return mat;
+  }
+
+  /**
+   * Generates the geometry for the leaves
+   */
+  createLeavesGeometry() {
     this.leavesMesh.geometry.dispose();
-    this.leavesMesh.geometry = g;
+    this.leavesMesh.geometry = this.#buildBufferGeometry(this.leaves);
     this.leavesMesh.material.dispose();
-
-    this.leavesMesh.material = mat;
-
+    this.leavesMesh.material = this.#createLeafMaterial();
     this.leavesMesh.castShadow = true;
     this.leavesMesh.receiveShadow = true;
   }

--- a/src/lib/tree.js
+++ b/src/lib/tree.js
@@ -858,13 +858,15 @@ export class Tree extends THREE.Group {
 
   /**
    * Creates the bark material from the current options
-   * @returns {THREE.MeshPhongMaterial}
+   * @returns {THREE.MeshStandardMaterial}
    */
   #createBarkMaterial() {
-    const mat = new THREE.MeshPhongMaterial({
+    const mat = new THREE.MeshStandardMaterial({
       name: 'branches',
       flatShading: this.options.bark.flatShading,
       color: new THREE.Color(this.options.bark.tint),
+      metalness: 0.0,
+      roughness: 1.0,
     });
 
     if (this.options.bark.textured) {
@@ -904,15 +906,17 @@ export class Tree extends THREE.Group {
   /**
    * Creates the leaf material, including the wind sway vertex shader, from
    * the current options
-   * @returns {THREE.MeshPhongMaterial}
+   * @returns {THREE.MeshStandardMaterial}
    */
   #createLeafMaterial() {
-    const mat = new THREE.MeshPhongMaterial({
+    const mat = new THREE.MeshStandardMaterial({
       name: 'leaves',
       map: this.options.leaves.map ?? null,
       color: new THREE.Color(this.options.leaves.tint),
       side: THREE.DoubleSide,
       alphaTest: this.options.leaves.alphaTest,
+      metalness: 0.0,
+      roughness: 1.0,
       dithering: true
     });
 

--- a/src/lib/tree.js
+++ b/src/lib/tree.js
@@ -141,7 +141,7 @@ export class Tree extends THREE.Group {
    * object inside this group. The renderer switches levels automatically
    * based on camera distance. All levels share one bark and one leaf
    * material, so update() animates wind at every level.
-   * @param {LODLevel[]} levels Ordered near-to-far level descriptors
+   * @param {LODLevel[]} levels Level descriptors, in any order
    */
   generateLODs(levels = Tree.defaultLODLevels) {
     this.#clearLOD();
@@ -153,7 +153,13 @@ export class Tree extends THREE.Group {
     this.lod = new THREE.LOD();
     this.lod.name = 'TreeLOD';
 
-    levels.forEach((level, index) => {
+    // THREE.LOD sorts its levels by distance internally, so sort here too and
+    // let the nearest level own the reused meshes regardless of input order.
+    const ordered = [...levels].sort(
+      (a, b) => (a.distance ?? 0) - (b.distance ?? 0),
+    );
+
+    ordered.forEach((level, index) => {
       const buffers = this.#meshSkeleton(level.detail ?? {});
 
       let branchesMesh, leavesMesh;
@@ -218,11 +224,11 @@ export class Tree extends THREE.Group {
   #clearLOD() {
     if (!this.lod) return;
 
-    this.lod.levels.forEach((level, index) => {
-      // Level 0 reuses branchesMesh/leavesMesh; their geometry and the
-      // shared materials are disposed by whichever generate path runs next.
-      if (index === 0) return;
+    this.lod.levels.forEach((level) => {
       for (const mesh of level.object.children) {
+        // One level reuses branchesMesh/leavesMesh; their geometry and the
+        // shared materials are disposed by whichever generate path runs next.
+        if (mesh === this.branchesMesh || mesh === this.leavesMesh) continue;
         mesh.geometry.dispose();
       }
     });

--- a/src/lib/tree.js
+++ b/src/lib/tree.js
@@ -885,7 +885,14 @@ export class Tree extends THREE.Group {
       if (maps.color) mat.map = apply(maps.color);
       if (maps.ao) mat.aoMap = apply(maps.ao);
       if (maps.normal) mat.normalMap = apply(maps.normal);
-      if (maps.roughness) mat.roughnessMap = apply(maps.roughness);
+      if (maps.roughness) {
+        mat.roughnessMap = apply(maps.roughness);
+        // Point metalnessMap at the same texture: metalness stays 0 because
+        // the metalness factor is 0, and GLTFExporter reuses the texture
+        // as-is instead of synthesizing a merged metal/rough PNG (and
+        // warning about it) when the two slots differ.
+        mat.metalnessMap = mat.roughnessMap;
+      }
     }
 
     return mat;
@@ -1062,7 +1069,14 @@ export class Tree extends THREE.Group {
         )
       );
 
-      mat.userData.shader = shader;
+      // Non-enumerable so JSON serialization (e.g. GLTFExporter's userData
+      // pass) skips the live shader object — Texture uniforms inside it are
+      // not serializable. update() still reads userData.shader normally.
+      Object.defineProperty(mat.userData, 'shader', {
+        value: shader,
+        configurable: true,
+        enumerable: false,
+      });
     };
 
     return mat;


### PR DESCRIPTION
## Summary

Adds first-class level-of-detail support to the ez-tree library, LOD integration in the demo app, a PBR material upgrade, and export fixes. Targets `release/v2.0.0`.

### Levels of Detail (library)

- Tree generation is split into a **skeleton pass** (consumes all RNG) and a **meshing pass**, so multiple detail levels mesh from one skeleton with an identical silhouette. Full-detail output is **bit-identical to before** (verified by hashing geometry buffers across 12 preset/seed combinations, including evergreen and trellis paths).
- `Tree.generateLODs(levels)` — hosts a `THREE.LOD` inside the tree group with automatic distance-based switching. All levels share one bark and one leaf material, so `update()` animates wind at every level. Calling `generate()` afterwards restores the flat single-mesh structure.
- `Tree.createGeometry(detail)` — raw branch/leaf `BufferGeometry` at any detail level (`sectionStride`, `segmentFactor`, `leafStride`, `leafScale`, `billboard`) for external instancing or custom LOD systems.
- `Tree.defaultLODLevels` — ~40% of full triangles at 100 units, ~20% at 250 units. LOD2 thins leaves at natural size with single billboards rather than scaling them up (coverage compensation beyond ~2x reads as balloon leaves).

### Demo app

- Background forest (100 trees) generates with LODs — cuts the forest from ~2M triangles to a fraction depending on camera position, and loads slightly faster (the old path generated each tree twice).
- Viewport stats HUD with live triangle/vertex counts and Full/LOD1/LOD2 preview buttons that lock the hero tree to a level for inspection.
- **Export LODs (ZIP)** button producing one GLB per level (`tree_LOD0/1/2.glb`); **Export GLB (Full Detail)** always exports full detail regardless of the active preview.

### Materials & textures

- Bark, leaf, ground, and grass materials switched from `MeshPhongMaterial` to **`MeshStandardMaterial`** (metalness 0, roughness 1). Bark roughness maps now actually affect shading, and GLB exports round-trip as native PBR. Clouds stay `MeshBasicMaterial` (unlit by design); skybox keeps its custom shader.
- Trimmed bark texture sets to the maps the demo uses (color, GL normal, roughness) — removed ambient-occlusion, displacement, and DirectX normal variants (~15 MB of LFS assets). The library still applies an `ao` map when a caller supplies one.

### Bug fixes

- **GLB export silently failed for the default bark**: Bark001 has no AO file, the dev server masks the 404 by serving `index.html`, and GLTFExporter aborts on the never-loaded texture. Texture loading now drops missing maps from the cache with a warning, and exports strip any never-loaded textures for the duration of the export.
- Silenced remaining exporter warnings: `metalnessMap` points at the roughness texture (metalness factor 0, exporter reuses it instead of synthesizing a merged PNG), and the leaf wind shader is stored as a non-enumerable `userData` property so JSON serialization skips it.

### Changelog

Restructured `CHANGELOG.md` from Added/Changed/Fixed into feature categories (Levels of Detail, Texture System, Rendering Improvements, Bug Fixes, Development & Tooling).

## Test plan

- [x] Geometry-hash parity: `generate()` output bit-identical to pre-refactor baseline for seeds {0, 1, 12345} × presets {Ash Medium, Pine Medium, Bush 1, Trellis} — re-verified after every subsequent change
- [x] `generateLODs()` level-0 geometry identical to `generate()` output
- [x] Repeated-call hygiene: `generateLODs()` ×2 → `generate()` → `generateLODs()` leaks no children, restores flat structure, shares materials across levels
- [x] Per-level triangle ratios across presets (LOD1 ~41–52%, LOD2 ~17–21%)
- [x] Visual pass in demo app: LOD switching in forest, wind sway at all levels, HUD counts update on preview switch
- [x] Export verified in isolated browser repro: untextured / partial / fully textured trees all produce valid GLBs with zero exporter warnings; broken-texture case reproduces the old failure and the strip fix resolves it
- [x] `npm run build:lib` (d.ts includes new API) and `npm run build:app`
- [ ] Open exported `tree.glb` / `tree_lods.zip` GLBs in a glTF viewer

## Follow-up

LOD2's leaf representation is an agreed stopgap. The planned upgrade is cluster cards (one quad per terminal branch textured from `leaf-cluster-gen` atlases) after this is reconciled with the `leafAtlas` branch, which touches the same leaf-generation code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)