### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2026-07-16
 
 ### Levels of Detail
 
@@ -36,6 +36,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - GLB export silently failed for trees using the default bark: the Bark001 texture set has no ambient-occlusion file, the dev server masks the 404 by serving `index.html`, and GLTFExporter aborts on the resulting never-loaded texture. Texture loading now drops missing maps from the cache, and exports strip any never-loaded textures from materials for the duration of the export.
 - The growth force was not being applied correctly. Branches now grow uniformly in the same world direction.
 - Child branches and leaves are now placed with stratified sampling (with a permuted slot assignment) instead of fixed angular spacing, eliminating visible spirals and one-sided clumping.
+
+### Demo App
+
+- Refreshed the UI with a glassmorphism design: tinted-glass panels and dialogs, a canopy-green accent palette, Space Grotesk typography, filled slider tracks, a live build-time stat, and a mobile bottom-sheet layout over a full-screen canvas.
 
 ### Development & Tooling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,45 +1,54 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Added
+### Levels of Detail
 
-- `bark.maps = { color, ao, normal, roughness }` and `leaves.map` slots on `TreeOptions` accept caller-supplied `THREE.Texture` instances; the library no longer bundles any textures.
-- `npm run dev` script and Vite mode-based alias so the dev server resolves `@dgreenheck/ez-tree` directly to `src/lib/` source — instant HMR with no rebuild step.
-- Git LFS tracking for `src/app/public/textures/**/*.{jpg,png,jpeg}`.
-- Demo app ships with 11 CC0 bark variants from ambientcg.com under `src/app/public/textures/bark/` with attribution in `src/app/public/textures/LICENSE.md`.
+- **`Tree.generateLODs(levels)`** builds the tree at multiple levels of detail hosted in a `THREE.LOD` inside the tree group, with automatic distance-based switching.
+  - All levels are meshed from a single skeleton, so the silhouette is identical across levels and switches don't pop.
+  - All levels share one bark and one leaf material, so `update()` animates wind at every level.
+  - Default levels (`Tree.defaultLODLevels`) reduce to ~40% of the full triangle count at 100 units and ~20% at 250 units.
+- **`Tree.createGeometry(detail)`** returns raw `{ branches, leaves }` `BufferGeometry` pairs at any detail level (`sectionStride`, `segmentFactor`, `leafStride`, `leafScale`, `billboard`) for external instancing or custom LOD systems.
+- Internally, tree generation is now split into a skeleton pass (all randomness) and a meshing pass (geometry emission). Output for a given seed is bit-identical to before; the undocumented internals `generateBranch`, `generateLeaf`, and `generateBranchIndices` were replaced by private methods.
+- Demo app:
+  - The background forest generates with LODs.
+  - New viewport stats overlay shows live triangle/vertex counts, with buttons to preview each LOD level on the hero tree.
+  - New "Export LODs (ZIP)" button downloads one GLB per LOD level; "Export GLB (Full Detail)" always exports full detail regardless of the active LOD preview.
 
-### Changed
+### Texture System (breaking)
 
+- The library no longer bundles any textures. `bark.maps = { color, ao, normal, roughness }` and `leaves.map` slots on `TreeOptions` accept caller-supplied `THREE.Texture` instances.
 - **Breaking:** removed `BarkType` and `LeafType` enums and the bundled-texture lookup. Callers must now load `THREE.Texture` instances themselves and assign them to `options.bark.maps` / `options.leaves.map`. `bark.type` / `leaves.type` strings are still carried through presets but are now purely informational identifiers the host app can use to resolve textures.
 - Bark UVs now scale with `branch.radius` (integer-rounded per branch) so bark feature size stays consistent across thick trunks and thin twigs; `bark.textureScale.x` now means "wraps per unit radius" rather than "wraps per branch" (existing preset values may need re-tuning).
+- Demo app ships with 11 CC0 bark variants from ambientcg.com under `src/app/public/textures/bark/` with attribution in `src/app/public/textures/LICENSE.md`, tracked via Git LFS.
+- Trimmed the bark texture sets to the maps the demo actually uses (color, GL normal, roughness) — removed the ambient-occlusion, displacement, and DirectX normal variants (~15 MB). The library still applies an `ao` map when a caller supplies one.
+
+### Rendering Improvements
+
+- Bark, leaf, ground, and grass materials switched from `MeshPhongMaterial` to `MeshStandardMaterial` (PBR). Bark roughness maps now actually affect shading, and GLB exports round-trip cleanly without the exporter's Phong-conversion warnings.
+- Leaves use custom rounded normals for softer, canopy-shaped shading (#43).
+
+### Bug Fixes
+
+- GLB export silently failed for trees using the default bark: the Bark001 texture set has no ambient-occlusion file, the dev server masks the 404 by serving `index.html`, and GLTFExporter aborts on the resulting never-loaded texture. Texture loading now drops missing maps from the cache, and exports strip any never-loaded textures from materials for the duration of the export.
+- The growth force was not being applied correctly. Branches now grow uniformly in the same world direction.
+- Child branches and leaves are now placed with stratified sampling (with a permuted slot assignment) instead of fixed angular spacing, eliminating visible spirals and one-sided clumping.
+
+### Development & Tooling
+
+- `npm run dev` script and Vite mode-based alias so the dev server resolves `@dgreenheck/ez-tree` directly to `src/lib/` source — instant HMR with no rebuild step.
 - Reorganized `src/app/public/` into `audio/`, `fonts/`, `images/`, `icons/`, `models/`, `textures/{bark,ground,leaves}/`; browser/SEO well-known files remain at the root.
 - Updated Dockerfile to Node 24 and removed the obsolete `version` attribute from `docker-compose.yml`.
-- Use custom rounded normals for leaves for softer shading (#43).
-
-### Fixed
-
-- The growth force was not being applied correctly. Branches should now grow uniformly in the same world direction.
-- Child branches and leaves are now placed with stratified sampling (with a permuted slot assignment) instead of fixed angular spacing, eliminating visible spirals and one-sided clumping.
 
 ## [1.1.0] - 2026-01-14
 
-### Added
-
 - Trellis system with force attraction for branch growth, enabling guided/structured tree shapes (#35).
-
-### Changed
-
 - Disabled the trellis system on presets where it isn't applicable.
 
 ## [1.0.1] - 2026-01-14
-
-### Changed
 
 - Redesigned the application UI (#34).
 - Reduced bundled asset sizes by more than 50%.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Initial 1.0 release of the procedural tree generator and demo application.
 
-[Unreleased]: https://github.com/dgreenheck/ez-tree/compare/v1.1.0...HEAD
+[2.0.0]: https://github.com/dgreenheck/ez-tree/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/dgreenheck/ez-tree/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/dgreenheck/ez-tree/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/dgreenheck/ez-tree/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -40,6 +40,40 @@ scene.add(tree);
 
 Any time the tree parameters are changed, you must call `generate()` to regenerate the geometry.
 
+## Levels of Detail (LODs)
+
+For scenes with many trees, `generateLODs()` builds the tree at multiple levels of detail hosted in a `THREE.LOD` object inside the tree group. The renderer automatically switches levels based on camera distance. All levels are meshed from the same skeleton, so the tree's silhouette stays consistent across switches — distant levels just use fewer ring segments and fewer (but larger) leaves.
+
+```js
+const tree = new Tree();
+tree.loadPreset('Ash Medium');
+tree.generateLODs(); // instead of generate()
+scene.add(tree);
+```
+
+The default levels (`Tree.defaultLODLevels`) switch at 100 and 250 units, reducing to roughly 40% and 20% of the full triangle count. You can pass custom levels:
+
+```js
+tree.generateLODs([
+  { distance: 0, detail: {} }, // full detail
+  {
+    distance: 80,
+    hysteresis: 0.05,
+    detail: {
+      sectionStride: 3,    // sample every 3rd ring along each branch
+      segmentFactor: 0.75, // reduce radial segments to 75% (min 3)
+      leafStride: 2,       // keep every 2nd leaf...
+      leafScale: 1.4,      // ...enlarged to preserve canopy coverage
+      billboard: 'single', // drop the second crossed leaf quad
+    },
+  },
+]);
+```
+
+All LOD levels share one bark material and one leaf material, so `tree.update(time)` animates wind at every level. Calling `generate()` afterwards tears the LOD down and restores the single full-detail mesh pair (note that exporting a tree generated with `generateLODs()` to GLB will include every level).
+
+If you have your own LOD or instancing system, `tree.createGeometry(detail)` returns raw `{ branches, leaves }` `BufferGeometry` pairs at any detail level without touching the tree's own meshes.
+
 # Running Standalone App Locally
 
 To run the standalone app locally, you first need to build the EZ-Tree library before running the app.

--- a/src/app/grass.js
+++ b/src/app/grass.js
@@ -108,7 +108,7 @@ export class Grass extends THREE.Object3D {
       mesh.traverse((o) => {
         if (o.isMesh && o.material) {
           if (o.material.map) {
-            o.material = new THREE.MeshPhongMaterial({ map: o.material.map });
+            o.material = new THREE.MeshStandardMaterial({ map: o.material.map, metalness: 0.0, roughness: 1.0 });
           }
           this.appendWindShader(o.material);
         }
@@ -127,7 +127,7 @@ export class Grass extends THREE.Object3D {
   }
 
   generateGrass() {
-    const grassMaterial = new THREE.MeshPhongMaterial({
+    const grassMaterial = new THREE.MeshStandardMaterial({
       map: _grassMesh.material.map,
       // Add some emission so grass has some color when not lit
       emissive: new THREE.Color(0x308040),
@@ -136,6 +136,8 @@ export class Grass extends THREE.Object3D {
       alphaTest: 0.5,
       depthTest: true,
       depthWrite: true,
+      metalness: 0.0,
+      roughness: 1.0,
       side: THREE.DoubleSide
     });
 

--- a/src/app/ground.js
+++ b/src/app/ground.js
@@ -43,11 +43,12 @@ export class Ground extends THREE.Mesh {
 
     fetchAssets().then(() => {
       // Ground plane with procedural grass/dirt texture
-      this.material = new THREE.MeshPhongMaterial({
+      this.material = new THREE.MeshStandardMaterial({
         emissive: new THREE.Color(0xffffff),
         emissiveIntensity: 0.01,
         normalMap: _dirtNormal,
-        shininess: 0.1
+        metalness: 0.0,
+        roughness: 1.0
       });
 
       this.material.onBeforeCompile = (shader) => {

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -37,6 +37,11 @@
     content="EZ-Tree is a procedural tree generator that allows you to create realistic 3D models of trees with ease.">
   <meta name="twitter:image" content="https://eztree.dev/og-image.png">
 
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&display=swap"
+    rel="stylesheet">
   <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 

--- a/src/app/public/styles.css
+++ b/src/app/public/styles.css
@@ -1,38 +1,37 @@
-@font-face {
-  font-family: 'Dumbeldor';
-  src: url('/fonts/dumbeldor.ttf'), format('ttf');
-  font-weight: normal;
-  font-style: normal;
-}
-
 /* ============================================================================
-   Base Styles
+   Design Tokens — "living glass" over the forest scene
    ============================================================================ */
 
 :root {
-  /* Dark gray color palette */
-  --color-gray-900: #121212;
-  --color-gray-800: #1a1a1a;
-  --color-gray-700: #242424;
-  --color-gray-600: #2e2e2e;
-  --color-gray-500: #3a3a3a;
-  --color-gray-400: #4a4a4a;
-  --color-gray-300: #6a6a6a;
-  --color-gray-200: #8a8a8a;
-  --color-gray-100: #aaaaaa;
+  /* Type */
+  --font-display: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'SF Mono', Monaco, 'Courier New', monospace;
 
-  /* UI Colors */
-  --panel-bg: rgba(18, 18, 18, 0.95);
-  --panel-border: rgba(255, 255, 255, 0.1);
-  --section-bg: rgba(255, 255, 255, 0.05);
-  --section-hover: rgba(255, 255, 255, 0.08);
-  --input-bg: rgba(0, 0, 0, 0.3);
-  --input-border: rgba(255, 255, 255, 0.1);
-  --text-primary: #ffffff;
-  --text-secondary: rgba(255, 255, 255, 0.7);
-  --text-muted: rgba(255, 255, 255, 0.4);
-  --accent: #6b9fff;
-  --accent-hover: #8bb4ff;
+  /* Canopy palette */
+  --canopy: #a4d97c;
+  --canopy-bright: #bfeb9a;
+  --canopy-deep: #77b34c;
+  --on-accent: #17240f;
+
+  /* Glass */
+  --glass-tint: 10, 16, 12;
+  --panel-bg: linear-gradient(170deg, rgba(var(--glass-tint), 0.68), rgba(var(--glass-tint), 0.5));
+  --panel-border: rgba(255, 255, 255, 0.14);
+  --glass-highlight: rgba(255, 255, 255, 0.16);
+  --glass-blur: blur(24px) saturate(1.6);
+  --card-bg: rgba(255, 255, 255, 0.055);
+  --card-hover: rgba(255, 255, 255, 0.09);
+  --input-bg: rgba(255, 255, 255, 0.06);
+  --input-border: rgba(255, 255, 255, 0.12);
+  --track-bg: rgba(255, 255, 255, 0.14);
+
+  /* Text */
+  --text-primary: #f2f5ef;
+  --text-secondary: rgba(240, 246, 236, 0.68);
+  --text-muted: rgba(240, 246, 236, 0.42);
+  --accent: var(--canopy);
+  --accent-hover: var(--canopy-bright);
 
   /* Spacing */
   --spacing-xs: 4px;
@@ -41,15 +40,18 @@
   --spacing-lg: 16px;
   --spacing-xl: 24px;
 
-  /* Borders - reduced by 50% */
-  --radius-sm: 3px;
-  --radius-md: 5px;
-  --radius-lg: 8px;
-  --radius-xl: 12px;
+  /* Radii — soft, glassy */
+  --radius-sm: 8px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-xl: 20px;
 
   /* Transitions */
   --transition-fast: 0.15s ease;
-  --transition-normal: 0.2s ease;
+  --transition-normal: 0.25s ease;
+
+  /* Shadows */
+  --shadow-glass: 0 16px 48px rgba(0, 0, 0, 0.35), inset 0 1px 0 var(--glass-highlight);
 }
 
 html,
@@ -63,18 +65,17 @@ body {
 }
 
 h1 {
-  font-family: 'Dumbeldor', serif;
+  font-family: var(--font-display);
   font-size: 3em;
-  text-decoration: underline;
 }
 
 h2 {
-  font-family: 'Dumbeldor', serif;
+  font-family: var(--font-display);
   font-size: 2em;
 }
 
 h3 {
-  font-family: 'Dumbeldor', serif;
+  font-family: var(--font-display);
   font-size: 1.5em;
 }
 
@@ -92,38 +93,47 @@ a {
   height: 100%;
 }
 
+:focus-visible {
+  outline: 2px solid var(--canopy-bright);
+  outline-offset: 2px;
+}
+
 /* ============================================================================
-   Custom Panel
+   Control Panel
    ============================================================================ */
 
 #ui-container {
   position: fixed;
-  top: 12px;
-  right: 12px;
-  width: 320px;
-  max-height: calc(100vh - 24px);
+  top: 16px;
+  right: 16px;
+  width: 336px;
+  max-height: calc(100vh - 32px);
   z-index: 100;
 }
 
 .custom-panel {
   background: var(--panel-bg);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
   border: 1px solid var(--panel-border);
   border-radius: var(--radius-xl);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-glass);
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - 24px);
+  max-height: calc(100vh - 32px);
 }
 
 .panel-header {
-  padding: var(--spacing-lg) var(--spacing-xl);
+  padding: var(--spacing-lg) var(--spacing-xl) var(--spacing-md);
   text-align: center;
-  border-bottom: 1px solid var(--panel-border);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   flex-shrink: 0;
   position: relative;
+}
+
+.panel-grabber {
+  display: none;
 }
 
 .panel-mobile-toggle {
@@ -131,17 +141,19 @@ a {
 }
 
 .panel-title {
-  font-family: 'Dumbeldor', serif;
-  font-size: 1.8em;
+  font-family: var(--font-display);
+  font-size: 1.35em;
+  font-weight: 700;
   color: var(--text-primary);
   margin: 0;
-  letter-spacing: 1px;
+  letter-spacing: 0.02em;
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
 }
 
 .panel-subtitle {
   font-size: 0.7em;
   color: var(--text-muted);
-  margin: var(--spacing-md) 0 0 0;
+  margin: var(--spacing-sm) 0 0 0;
   text-transform: uppercase;
   letter-spacing: 2px;
 }
@@ -152,7 +164,7 @@ a {
   overflow-x: hidden;
   padding: var(--spacing-md);
   scrollbar-width: thin;
-  scrollbar-color: var(--gray-400) transparent;
+  scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
 }
 
 .panel-scroll-area::-webkit-scrollbar {
@@ -164,22 +176,26 @@ a {
 }
 
 .panel-scroll-area::-webkit-scrollbar-thumb {
-  background: var(--color-gray-400);
+  background: rgba(255, 255, 255, 0.2);
   border-radius: 3px;
 }
 
 .panel-scroll-area::-webkit-scrollbar-thumb:hover {
-  background: var(--color-gray-300);
+  background: rgba(255, 255, 255, 0.35);
 }
 
 /* ============================================================================
-   Tab Navigation
+   Tab Navigation — segmented glass control
    ============================================================================ */
 
 .tab-nav {
   display: flex;
-  gap: var(--spacing-sm);
+  gap: 3px;
   margin-bottom: var(--spacing-md);
+  padding: 3px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius-md);
 }
 
 .tab-button {
@@ -189,9 +205,9 @@ a {
   justify-content: center;
   gap: var(--spacing-sm);
   padding: var(--spacing-sm) var(--spacing-md);
-  background: var(--input-bg);
-  border: 1px solid var(--input-border);
-  border-radius: var(--radius-md);
+  background: transparent;
+  border: none;
+  border-radius: calc(var(--radius-md) - 3px);
   color: var(--text-secondary);
   font-size: 0.85em;
   font-weight: 500;
@@ -200,23 +216,19 @@ a {
 }
 
 .tab-button:hover {
-  background: var(--section-hover);
+  background: var(--card-hover);
   color: var(--text-primary);
 }
 
 .tab-button.active {
   background: var(--accent);
-  border-color: var(--accent);
-  color: var(--color-gray-900);
+  color: var(--on-accent);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
 }
 
 .tab-button .icon {
   width: 18px;
   height: 18px;
-}
-
-.tab-button.active .icon {
-  stroke: var(--color-gray-900);
 }
 
 .tab-label {
@@ -232,20 +244,24 @@ a {
 }
 
 /* ============================================================================
-   Sections
+   Sections — frosted cards with smooth accordion
    ============================================================================ */
 
 .panel-section {
-  background: var(--section-bg);
-  border-radius: var(--radius-md);
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
   margin-bottom: var(--spacing-sm);
   overflow: hidden;
-  border: 1px solid transparent;
-  transition: border-color var(--transition-fast);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  transition: border-color var(--transition-fast), background var(--transition-fast);
 }
 
 .panel-section:hover {
   border-color: var(--panel-border);
+}
+
+.panel-section.expanded {
+  background: rgba(255, 255, 255, 0.04);
 }
 
 .section-header {
@@ -258,7 +274,7 @@ a {
 }
 
 .section-header:hover {
-  background: var(--section-hover);
+  background: var(--card-hover);
 }
 
 .section-header .icon {
@@ -267,6 +283,10 @@ a {
   margin-right: var(--spacing-sm);
   color: var(--text-secondary);
   flex-shrink: 0;
+}
+
+.panel-section.expanded .section-header .icon {
+  color: var(--accent);
 }
 
 .section-title {
@@ -289,13 +309,23 @@ a {
 }
 
 .section-content {
-  max-height: 0;
-  overflow: hidden;
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--transition-normal);
 }
 
-.panel-section.expanded .section-content {
-  max-height: 2000px;
-  padding: var(--spacing-xs) var(--spacing-md) var(--spacing-md);
+.panel-section.expanded > .section-content {
+  grid-template-rows: 1fr;
+}
+
+.section-content-inner {
+  overflow: hidden;
+  min-height: 0;
+  padding: 0 var(--spacing-md);
+}
+
+.panel-section.expanded > .section-content > .section-content-inner {
+  padding-bottom: var(--spacing-md);
 }
 
 /* ============================================================================
@@ -303,7 +333,7 @@ a {
    ============================================================================ */
 
 .panel-subsection {
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(0, 0, 0, 0.22);
   border-radius: var(--radius-sm);
   margin-top: var(--spacing-sm);
   overflow: hidden;
@@ -319,7 +349,7 @@ a {
 }
 
 .subsection-header:hover {
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(255, 255, 255, 0.04);
 }
 
 .subsection-title {
@@ -341,13 +371,23 @@ a {
 }
 
 .subsection-content {
-  max-height: 0;
-  overflow: hidden;
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--transition-normal);
 }
 
-.panel-subsection.expanded .subsection-content {
-  max-height: 1000px;
-  padding: var(--spacing-xs) var(--spacing-md) var(--spacing-md);
+.panel-subsection.expanded > .subsection-content {
+  grid-template-rows: 1fr;
+}
+
+.subsection-content-inner {
+  overflow: hidden;
+  min-height: 0;
+  padding: 0 var(--spacing-md);
+}
+
+.panel-subsection.expanded > .subsection-content > .subsection-content-inner {
+  padding-bottom: var(--spacing-md);
 }
 
 /* ============================================================================
@@ -373,7 +413,7 @@ a {
 }
 
 /* ============================================================================
-   Sliders
+   Sliders — filled track shows the value at a glance
    ============================================================================ */
 
 .slider-wrapper {
@@ -390,7 +430,10 @@ a {
   -webkit-appearance: none;
   appearance: none;
   height: 4px;
-  background: var(--color-gray-600);
+  background: linear-gradient(to right,
+      var(--accent) 0%,
+      var(--accent) var(--fill, 50%),
+      var(--track-bg) var(--fill, 50%));
   border-radius: 2px;
   outline: none;
   cursor: pointer;
@@ -401,24 +444,27 @@ a {
   appearance: none;
   width: 14px;
   height: 14px;
-  background: var(--text-primary);
+  background: #fff;
   border-radius: 50%;
   cursor: pointer;
-  transition: transform var(--transition-fast);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
   border: none;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
 }
 
 .slider::-webkit-slider-thumb:hover {
-  transform: scale(1.1);
+  transform: scale(1.15);
+  box-shadow: 0 0 0 4px rgba(164, 217, 124, 0.25);
 }
 
 .slider::-moz-range-thumb {
   width: 14px;
   height: 14px;
-  background: var(--text-primary);
+  background: #fff;
   border-radius: 50%;
   cursor: pointer;
   border: none;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
 }
 
 .slider-value {
@@ -429,12 +475,14 @@ a {
   color: var(--text-primary);
   text-align: right;
   font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+  font-variant-numeric: tabular-nums;
   background: var(--input-bg);
   padding: var(--spacing-xs) var(--spacing-sm);
   border-radius: var(--radius-sm);
   border: 1px solid var(--input-border);
   box-sizing: content-box;
   -moz-appearance: textfield;
+  transition: border-color var(--transition-fast);
 }
 
 .slider-value::-webkit-outer-spin-button,
@@ -464,6 +512,7 @@ a {
   height: 28px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--input-border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15);
 }
 
 .color-picker {
@@ -503,16 +552,17 @@ a {
   font-size: 0.8em;
   cursor: pointer;
   outline: none;
-  transition: border-color var(--transition-fast);
+  transition: border-color var(--transition-fast), background var(--transition-fast);
   appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23888' d='M6 8L2 4h8z'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23aaa' d='M6 8L2 4h8z'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 10px center;
   padding-right: 30px;
 }
 
 .select:hover {
-  border-color: var(--color-gray-400);
+  background-color: var(--card-hover);
+  border-color: rgba(255, 255, 255, 0.2);
 }
 
 .select:focus {
@@ -520,13 +570,13 @@ a {
 }
 
 .select option {
-  background: var(--color-gray-800);
+  background: #1a221c;
   color: var(--text-primary);
   padding: var(--spacing-sm);
 }
 
 /* ============================================================================
-   Toggle Button
+   Toggle
    ============================================================================ */
 
 .toggle-wrapper {
@@ -538,7 +588,7 @@ a {
 .toggle {
   width: 40px;
   height: 22px;
-  background: var(--color-gray-600);
+  background: rgba(255, 255, 255, 0.14);
   border: none;
   border-radius: 11px;
   cursor: pointer;
@@ -548,7 +598,7 @@ a {
 }
 
 .toggle:hover {
-  background: var(--color-gray-500);
+  background: rgba(255, 255, 255, 0.22);
 }
 
 .toggle.active {
@@ -564,6 +614,7 @@ a {
   background: white;
   border-radius: 50%;
   transition: transform var(--transition-fast);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
 }
 
 .toggle.active .toggle-knob {
@@ -581,8 +632,8 @@ a {
   justify-content: center;
   gap: var(--spacing-sm);
   padding: var(--spacing-sm) var(--spacing-md);
-  background: var(--section-bg);
-  border: 1px solid var(--panel-border);
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
   font-size: 0.85em;
@@ -593,12 +644,13 @@ a {
 }
 
 .panel-button:hover {
-  background: var(--section-hover);
-  border-color: var(--color-gray-400);
+  background: var(--card-hover);
+  border-color: rgba(255, 255, 255, 0.25);
 }
 
 .panel-button:active {
-  background: var(--color-gray-600);
+  background: rgba(255, 255, 255, 0.03);
+  transform: translateY(1px);
 }
 
 .panel-button .icon {
@@ -620,6 +672,136 @@ a {
   font-size: 0.8em;
   color: var(--text-secondary);
   font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ============================================================================
+   Panel Footer
+   ============================================================================ */
+
+.panel-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-md);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  flex-shrink: 0;
+}
+
+.panel-footer-heading {
+  margin: 0 0 var(--spacing-xs);
+  font-size: 0.75em;
+  color: var(--text-muted);
+}
+
+.panel-footer-link {
+  font-size: 0.85em;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+.panel-footer-link:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+/* ============================================================================
+   Stats HUD — live readout while shaping the tree
+   ============================================================================ */
+
+#stats-overlay {
+  position: fixed;
+  top: 16px;
+  left: 16px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background: var(--panel-bg);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-glass);
+}
+
+.stats-counts {
+  display: flex;
+  gap: var(--spacing-lg);
+}
+
+.stats-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.stats-value {
+  font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: 1.25em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.2;
+}
+
+.stats-value.pulse {
+  animation: stat-pulse 0.7s ease-out;
+}
+
+@keyframes stat-pulse {
+  0% {
+    color: var(--canopy-bright);
+    text-shadow: 0 0 12px rgba(164, 217, 124, 0.6);
+  }
+
+  100% {
+    color: var(--text-primary);
+    text-shadow: none;
+  }
+}
+
+.stats-label {
+  font-size: 0.7em;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+
+.lod-switcher {
+  display: flex;
+  gap: 2px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius-sm);
+  padding: 2px;
+}
+
+.lod-button {
+  flex: 1;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: transparent;
+  border: none;
+  border-radius: calc(var(--radius-sm) - 2px);
+  color: var(--text-secondary);
+  font-size: 0.75em;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.lod-button:hover {
+  color: var(--text-primary);
+  background: var(--card-hover);
+}
+
+.lod-button.active {
+  background: var(--accent);
+  color: var(--on-accent);
 }
 
 /* ============================================================================
@@ -633,17 +815,25 @@ a {
 .audio-icon {
   display: none;
   position: fixed;
-  top: 16px;
-  left: 80px;
-  width: 40px;
-  height: 40px;
+  bottom: 16px;
+  left: 16px;
+  width: 46px;
+  height: 46px;
+  padding: 10px;
+  box-sizing: border-box;
+  background: rgba(var(--glass-tint), 0.5);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  border: 1px solid var(--panel-border);
+  border-radius: 50%;
+  box-shadow: var(--shadow-glass);
   cursor: pointer;
   transition: transform var(--transition-fast), filter var(--transition-fast);
   z-index: 101;
 }
 
 .audio-icon:hover {
-  transform: scale(1.1);
+  transform: scale(1.08);
   filter: brightness(1.2);
 }
 
@@ -679,9 +869,11 @@ a {
 }
 
 #loading-text {
-  font-size: 5em;
+  font-size: 3em;
+  font-weight: 600;
+  letter-spacing: 0.15em;
   color: white;
-  font-family: 'Dumbeldor', serif;
+  font-family: var(--font-display);
   text-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
 }
 
@@ -695,7 +887,9 @@ a {
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.85);
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -711,17 +905,19 @@ a {
 }
 
 .about-dialog {
-  background: linear-gradient(135deg, #1e1e1e, #333);
+  background: var(--panel-bg);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
   color: #fff;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-xl);
   width: 90%;
   max-width: 500px;
   padding: 32px;
   margin: 16px;
   text-align: center;
   position: relative;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: var(--shadow-glass);
+  border: 1px solid var(--panel-border);
 }
 
 .about-dialog img {
@@ -750,18 +946,18 @@ a {
 .close-button {
   margin-top: 24px;
   padding: 12px 24px;
-  border: none;
-  background: var(--color-gray-600);
+  border: 1px solid var(--input-border);
+  background: var(--input-bg);
   color: #fff;
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: background 0.2s;
-  font-family: 'Dumbeldor', serif;
+  font-family: var(--font-display);
   font-size: 1.2em;
 }
 
 .close-button:hover {
-  background: var(--color-gray-500);
+  background: var(--card-hover);
 }
 
 /* Course CTA in About Dialog */
@@ -777,6 +973,7 @@ a {
   text-decoration: none;
   transition: transform 0.2s, box-shadow 0.2s;
   max-width: 280px;
+  position: relative;
 }
 
 .course-cta:hover {
@@ -794,12 +991,8 @@ a {
   white-space: nowrap;
 }
 
-.course-cta {
-  position: relative;
-}
-
 .course-cta-title {
-  font-family: 'Dumbeldor', serif;
+  font-family: var(--font-display);
   font-size: 1.3em;
   color: #fff;
 }
@@ -810,71 +1003,25 @@ a {
 }
 
 /* ============================================================================
-   Panel Footer
-   ============================================================================ */
-
-.panel-footer {
-  padding: var(--spacing-sm) var(--spacing-md);
-  border-top: 1px solid var(--panel-border);
-  text-align: center;
-  flex-shrink: 0;
-}
-
-.panel-footer-link {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-xs);
-  margin-top: 8px;
-  margin-bottom: 8px;
-  color: var(--text-primary);
-  font-size: 0.85em;
-  text-decoration: none;
-  transition: color var(--transition-fast);
-}
-
-.panel-footer-link:hover {
-  color: var(--accent);
-}
-
-.panel-footer-link .icon {
-  width: 12px;
-  height: 12px;
-}
-
-/* ============================================================================
-   Mobile Responsive Styles
+   Mobile — bottom sheet over a full-screen scene
    ============================================================================ */
 
 @media (max-width: 800px) {
-  #root {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-  }
-
-  #app {
-    flex: 1;
-    height: auto;
-    min-height: 0;
-  }
-
   #ui-container {
-    position: relative;
+    position: fixed;
     top: auto;
-    right: auto;
+    right: 0;
+    bottom: 0;
+    left: 0;
     width: 100%;
     max-height: none;
-    flex-shrink: 0;
   }
 
   .custom-panel {
-    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-    max-height: 55vh;
-    height: auto;
-  }
-
-  .custom-panel.collapsed {
-    max-height: none;
+    border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+    border-bottom: none;
+    max-height: 62vh;
+    padding-bottom: env(safe-area-inset-bottom);
   }
 
   .custom-panel.collapsed .panel-scroll-area,
@@ -882,8 +1029,18 @@ a {
     display: none;
   }
 
-  .custom-panel.collapsed .panel-mobile-toggle .icon {
-    transform: rotate(180deg);
+  .panel-header {
+    cursor: pointer;
+    padding: var(--spacing-sm) var(--spacing-lg) var(--spacing-md);
+  }
+
+  .panel-grabber {
+    display: block;
+    width: 40px;
+    height: 4px;
+    border-radius: 2px;
+    background: rgba(255, 255, 255, 0.3);
+    margin: 0 auto var(--spacing-sm);
   }
 
   .panel-mobile-toggle {
@@ -891,45 +1048,59 @@ a {
     align-items: center;
     justify-content: center;
     position: absolute;
-    top: var(--spacing-sm);
-    right: var(--spacing-md);
-    width: 32px;
-    height: 32px;
-    background: var(--section-bg);
-    border: 1px solid var(--panel-border);
-    border-radius: var(--radius-sm);
+    top: 50%;
+    right: var(--spacing-lg);
+    transform: translateY(-50%);
+    width: 36px;
+    height: 36px;
+    background: var(--input-bg);
+    border: 1px solid var(--input-border);
+    border-radius: 50%;
     cursor: pointer;
     color: var(--text-secondary);
     padding: 0;
-  }
-
-  .panel-mobile-toggle:hover {
-    background: var(--section-hover);
-    color: var(--text-primary);
   }
 
   .panel-mobile-toggle .icon {
     width: 18px;
     height: 18px;
     transition: transform var(--transition-fast);
+    transform: rotate(180deg);
   }
 
-  .panel-header {
-    padding: var(--spacing-md) var(--spacing-lg);
+  .custom-panel.collapsed .panel-mobile-toggle .icon {
+    transform: rotate(0deg);
   }
 
   .panel-title {
-    font-size: 1.4em;
+    font-size: 1.3em;
   }
 
   .panel-subtitle {
     font-size: 0.6em;
+    margin-top: var(--spacing-xs);
   }
 
   .control-label {
     width: 70px;
     min-width: 70px;
     font-size: 0.75em;
+  }
+
+  /* Larger touch targets */
+  .slider {
+    height: 6px;
+    border-radius: 3px;
+  }
+
+  .slider::-webkit-slider-thumb {
+    width: 20px;
+    height: 20px;
+  }
+
+  .slider::-moz-range-thumb {
+    width: 20px;
+    height: 20px;
   }
 
   .slider-value {
@@ -942,25 +1113,45 @@ a {
     padding: var(--spacing-sm);
   }
 
-  .tab-label {
-    display: none;
+  #stats-overlay {
+    top: 12px;
+    left: 12px;
+    padding: var(--spacing-sm) var(--spacing-md);
+    gap: var(--spacing-xs);
   }
 
-  .tab-button .icon {
-    width: 20px;
-    height: 20px;
+  .stats-counts {
+    gap: var(--spacing-md);
+  }
+
+  .stats-value {
+    font-size: 0.95em;
+  }
+
+  .stats-label {
+    font-size: 0.6em;
+  }
+
+  .audio-icon {
+    bottom: auto;
+    left: auto;
+    top: 12px;
+    right: 12px;
+    width: 40px;
+    height: 40px;
+    padding: 8px;
   }
 }
 
 @media (max-width: 675px) {
   #loading-text {
-    font-size: 4em;
+    font-size: 2.5em;
   }
 }
 
 @media (max-width: 575px) {
   #loading-text {
-    font-size: 3em;
+    font-size: 2em;
   }
 
   .about-dialog {
@@ -982,7 +1173,7 @@ a {
 
 @media (max-width: 475px) {
   #loading-text {
-    font-size: 2em;
+    font-size: 1.6em;
   }
 
   .control-label {
@@ -996,91 +1187,17 @@ a {
     min-width: 38px;
   }
 }
+
 /* ============================================================================
-   Stats Overlay (viewport HUD with LOD preview switching)
+   Reduced Motion
    ============================================================================ */
 
-#stats-overlay {
-  position: fixed;
-  top: 12px;
-  left: 12px;
-  z-index: 100;
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-sm);
-  padding: var(--spacing-md) var(--spacing-lg);
-  background: var(--panel-bg);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border: 1px solid var(--panel-border);
-  border-radius: var(--radius-xl);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
-}
+@media (prefers-reduced-motion: reduce) {
 
-.stats-counts {
-  display: flex;
-  gap: var(--spacing-lg);
-}
-
-.stats-stat {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-}
-
-.stats-value {
-  font-family: 'SF Mono', Monaco, 'Courier New', monospace;
-  font-size: 1.25em;
-  font-weight: 600;
-  color: var(--text-primary);
-  line-height: 1.2;
-}
-
-.stats-label {
-  font-size: 0.7em;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--text-muted);
-}
-
-.lod-switcher {
-  display: flex;
-  gap: 2px;
-  background: var(--input-bg);
-  border: 1px solid var(--input-border);
-  border-radius: var(--radius-sm);
-  padding: 2px;
-}
-
-.lod-button {
-  flex: 1;
-  padding: var(--spacing-xs) var(--spacing-sm);
-  background: transparent;
-  border: none;
-  border-radius: calc(var(--radius-sm) - 2px);
-  color: var(--text-secondary);
-  font-size: 0.75em;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all var(--transition-fast);
-}
-
-.lod-button:hover {
-  color: var(--text-primary);
-  background: var(--section-hover);
-}
-
-.lod-button.active {
-  background: var(--accent);
-  color: #fff;
-}
-
-@media (max-width: 800px) {
-  #stats-overlay {
-    padding: var(--spacing-sm) var(--spacing-md);
-  }
-
-  .stats-value {
-    font-size: 1em;
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
   }
 }

--- a/src/app/public/styles.css
+++ b/src/app/public/styles.css
@@ -996,3 +996,91 @@ a {
     min-width: 38px;
   }
 }
+/* ============================================================================
+   Stats Overlay (viewport HUD with LOD preview switching)
+   ============================================================================ */
+
+#stats-overlay {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background: var(--panel-bg);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-xl);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.stats-counts {
+  display: flex;
+  gap: var(--spacing-lg);
+}
+
+.stats-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.stats-value {
+  font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+  font-size: 1.25em;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.2;
+}
+
+.stats-label {
+  font-size: 0.7em;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+
+.lod-switcher {
+  display: flex;
+  gap: 2px;
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius-sm);
+  padding: 2px;
+}
+
+.lod-button {
+  flex: 1;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: transparent;
+  border: none;
+  border-radius: calc(var(--radius-sm) - 2px);
+  color: var(--text-secondary);
+  font-size: 0.75em;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.lod-button:hover {
+  color: var(--text-primary);
+  background: var(--section-hover);
+}
+
+.lod-button.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+@media (max-width: 800px) {
+  #stats-overlay {
+    padding: var(--spacing-sm) var(--spacing-md);
+  }
+
+  .stats-value {
+    font-size: 1em;
+  }
+}

--- a/src/app/public/textures/bark/Bark001_1K-JPG/Bark001_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark001_1K-JPG/Bark001_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9376be8609cd3e0fe3b4d28902676089dd38db64163865e8d05374dedf78b58
-size 418260

--- a/src/app/public/textures/bark/Bark001_1K-JPG/Bark001_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark001_1K-JPG/Bark001_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c4b974442abb3609df973ce169a603cff3626a9d4ed6128563018811144346b0
-size 1271049

--- a/src/app/public/textures/bark/Bark002_1K-JPG/Bark002_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark002_1K-JPG/Bark002_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9eb76535ddabf3eab1f11be6d46e4866bacd5ed8229910a5e4e3471ba36db37
-size 602552

--- a/src/app/public/textures/bark/Bark002_1K-JPG/Bark002_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark002_1K-JPG/Bark002_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3310597dbbc1b3576b3e66cfd90d04837c0c8b8ae2e91a64a08384b6cd6470fa
-size 406525

--- a/src/app/public/textures/bark/Bark002_1K-JPG/Bark002_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark002_1K-JPG/Bark002_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee5a49dd3fab84bfa4e4e07dfbe293806de7dafdc5541d752809d329d0a20741
-size 2470186

--- a/src/app/public/textures/bark/Bark003_1K-JPG/Bark003_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark003_1K-JPG/Bark003_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:60351dd5bce5cc8d6be6288e207bd9be322c0ae6a834ff38e12914652cff132e
-size 554470

--- a/src/app/public/textures/bark/Bark003_1K-JPG/Bark003_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark003_1K-JPG/Bark003_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:388bd751e4bf7019468f9da77985e3b0bf720b504fe92415095d2f7dc6760fc6
-size 429168

--- a/src/app/public/textures/bark/Bark003_1K-JPG/Bark003_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark003_1K-JPG/Bark003_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f8f0cee1d93408e4c14af6bdc4419cc7428a7efd8e0e14648b9e98fec0578c4
-size 2570614

--- a/src/app/public/textures/bark/Bark004_1K-JPG/Bark004_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark004_1K-JPG/Bark004_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d039dfcfa807a2c4915d5505eb935a1a173da5dc35edf7827a516b8911b48648
-size 554184

--- a/src/app/public/textures/bark/Bark004_1K-JPG/Bark004_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark004_1K-JPG/Bark004_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3032a272c5eb7331678951f4c1508b2da6c5673e1cddc968d66a6189ccb139d
-size 373807

--- a/src/app/public/textures/bark/Bark004_1K-JPG/Bark004_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark004_1K-JPG/Bark004_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d14c5d8bf4b38c842d2ce845c377a3951068c0d8dd95e4d5878c7cd4e3436e73
-size 2369603

--- a/src/app/public/textures/bark/Bark006_1K-JPG/Bark006_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark006_1K-JPG/Bark006_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e068921883e9d03a68f732d660fd8dfb9d9b00f9d7e1a3fb832267bba9888b
-size 541386

--- a/src/app/public/textures/bark/Bark006_1K-JPG/Bark006_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark006_1K-JPG/Bark006_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:30b3455238ccd63857617a9b023ae52ecc5d3e6950b40c6e6c9d7bc95cce7315
-size 390693

--- a/src/app/public/textures/bark/Bark006_1K-JPG/Bark006_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark006_1K-JPG/Bark006_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0f2a4fdcb46e94be0f2ccd1c7e1fdf374cf900e627938ae36d997ac0f696d31
-size 2302212

--- a/src/app/public/textures/bark/Bark007_1K-JPG/Bark007_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark007_1K-JPG/Bark007_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2b5a1f0ca3291977ecf78e62cac78f86d24c146018fc97b3952e6461e6887e63
-size 659228

--- a/src/app/public/textures/bark/Bark007_1K-JPG/Bark007_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark007_1K-JPG/Bark007_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:46240d4f9a427f25ccbc18496a76f343621405953e440316c4ef5069677f748c
-size 527892

--- a/src/app/public/textures/bark/Bark007_1K-JPG/Bark007_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark007_1K-JPG/Bark007_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5d7f877a4d04b7abf7ec74a74a737726dd68912375953ffc748459ceb68d4ee
-size 2471328

--- a/src/app/public/textures/bark/Bark008_1K-JPG/Bark008_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark008_1K-JPG/Bark008_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3c76d414920916facd6945f83910618afc1c600dec678d45a8e4fca8156a47fa
-size 299783

--- a/src/app/public/textures/bark/Bark008_1K-JPG/Bark008_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark008_1K-JPG/Bark008_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91c3950c8c84f88f714f0d30daea8796a64c31ee68055e6fcc214d6539d3be61
-size 239875

--- a/src/app/public/textures/bark/Bark008_1K-JPG/Bark008_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark008_1K-JPG/Bark008_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:32c11f36e1f1f9d26cd362d118e5671135f74d144e03b11b46ccef7ded87c2c8
-size 1177751

--- a/src/app/public/textures/bark/Bark012_1K-JPG/Bark012_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark012_1K-JPG/Bark012_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4f695890ad517325cc00659e6e66fa9388ee6470d525b78476c643d6c4c1e3b7
-size 758060

--- a/src/app/public/textures/bark/Bark012_1K-JPG/Bark012_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark012_1K-JPG/Bark012_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba9f34d58b68e6fd5a0800ee497d3893e87d014b3afc6f4f644ec02b0f241dda
-size 598905

--- a/src/app/public/textures/bark/Bark012_1K-JPG/Bark012_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark012_1K-JPG/Bark012_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c6d2bbcadb69573175cf51b8a8813b03ee5e1a4321c1740f3827de9efb8c2762
-size 2450338

--- a/src/app/public/textures/bark/Bark013_1K-JPG/Bark013_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark013_1K-JPG/Bark013_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1e62297e1fb3a60c46d59b60ae15962466faf888fde8caaab000035c0cf79216
-size 705883

--- a/src/app/public/textures/bark/Bark013_1K-JPG/Bark013_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark013_1K-JPG/Bark013_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5253f7ba9c5707294dc4a33a5b3bfd7b50d9c4fbb007bb4f9642dcb190e777d4
-size 522502

--- a/src/app/public/textures/bark/Bark013_1K-JPG/Bark013_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark013_1K-JPG/Bark013_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:83457007f4739fd4dfe77f6d22a081aee1ba9266702f74ee082343883cd5c0e0
-size 2137901

--- a/src/app/public/textures/bark/Bark014_1K-JPG/Bark014_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark014_1K-JPG/Bark014_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:92ece37c217aa0609a02327a860520bfd3145cabe82bef1cf9fad601d3b86f15
-size 753753

--- a/src/app/public/textures/bark/Bark014_1K-JPG/Bark014_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark014_1K-JPG/Bark014_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0157cc50fd51efd0ce1d91a61c9e3da4f2ead0df026b04eefde7e79785968a69
-size 394989

--- a/src/app/public/textures/bark/Bark014_1K-JPG/Bark014_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark014_1K-JPG/Bark014_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5f8cdd6e3f30b4c4a6e287330b3875a9dbed11767c2f590c916053a9c5723d48
-size 1747079

--- a/src/app/public/textures/bark/Bark015_1K-JPG/Bark015_1K-JPG_AmbientOcclusion.jpg
+++ b/src/app/public/textures/bark/Bark015_1K-JPG/Bark015_1K-JPG_AmbientOcclusion.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f1f76bec73110050d943f42f4f51b636590239fce90aba0d3d81526c16672e78
-size 831667

--- a/src/app/public/textures/bark/Bark015_1K-JPG/Bark015_1K-JPG_Displacement.jpg
+++ b/src/app/public/textures/bark/Bark015_1K-JPG/Bark015_1K-JPG_Displacement.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d23c3178caae573e56c3d409c7571ee0865ed03e2d3372ea1861a21bd24447ae
-size 438076

--- a/src/app/public/textures/bark/Bark015_1K-JPG/Bark015_1K-JPG_NormalDX.jpg
+++ b/src/app/public/textures/bark/Bark015_1K-JPG/Bark015_1K-JPG_NormalDX.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c43be48cadd4f5e10275165190785183b5cc283e9bdc28f1404fb9bb333c1e02
-size 2176851

--- a/src/app/scene.js
+++ b/src/app/scene.js
@@ -70,9 +70,9 @@ export async function createScene(renderer) {
 
     const t = new Tree();
     t.position.set(r * Math.cos(theta), 0, r * Math.sin(theta));
-    loadPresetWithTextures(t, presets[index]);
+    loadPresetWithTextures(t, presets[index], false);
     t.options.seed = 10000 * Math.random();
-    t.generate();
+    t.generateLODs();
     t.castShadow = true;
     t.receiveShadow = true;
 

--- a/src/app/textures.js
+++ b/src/app/textures.js
@@ -28,20 +28,25 @@ const textureLoader = new THREE.TextureLoader();
 const barkCache = new Map();
 const leafCache = new Map();
 
-function loadColor(url) {
-  const t = textureLoader.load(url);
+// The onError callbacks below matter: a texture whose file is missing keeps
+// an undefined image forever (the dev server masks the 404 by serving
+// index.html). That renders harmlessly but breaks GLTF export, so a failed
+// load must remove the map from the cache entirely.
+
+function loadColor(url, onError) {
+  const t = textureLoader.load(url, undefined, undefined, onError);
   t.colorSpace = THREE.SRGBColorSpace;
   return t;
 }
 
-function loadLinear(url) {
-  return textureLoader.load(url);
+function loadLinear(url, onError) {
+  return textureLoader.load(url, undefined, undefined, onError);
 }
 
 /**
  * Returns a cached set of THREE.Texture maps for the given bark type.
  * @param {string} type - one of BarkType values
- * @returns {{ color: THREE.Texture, ao: THREE.Texture, normal: THREE.Texture, roughness: THREE.Texture } | null}
+ * @returns {{ color: THREE.Texture, normal: THREE.Texture, roughness: THREE.Texture } | null}
  */
 export function getBarkMaps(type) {
   if (!BarkType[type]) return null;
@@ -49,12 +54,14 @@ export function getBarkMaps(type) {
 
   const dir = `${type}_1K-JPG`;
   const base = `/textures/bark/${dir}/${dir}`;
-  const maps = {
-    color: loadColor(`${base}_Color.jpg`),
-    ao: loadLinear(`${base}_AmbientOcclusion.jpg`),
-    normal: loadLinear(`${base}_NormalGL.jpg`),
-    roughness: loadLinear(`${base}_Roughness.jpg`),
+  const maps = {};
+  const drop = (key) => () => {
+    console.warn(`Missing bark texture: ${base}_… (${key}); skipping this map.`);
+    maps[key] = null;
   };
+  maps.color = loadColor(`${base}_Color.jpg`, drop('color'));
+  maps.normal = loadLinear(`${base}_NormalGL.jpg`, drop('normal'));
+  maps.roughness = loadLinear(`${base}_Roughness.jpg`, drop('roughness'));
   barkCache.set(type, maps);
   return maps;
 }
@@ -66,7 +73,10 @@ export function getBarkMaps(type) {
  */
 export function getLeafMap(type) {
   if (leafCache.has(type)) return leafCache.get(type);
-  const texture = loadColor(`/textures/leaves/${type}.png`);
+  const texture = loadColor(`/textures/leaves/${type}.png`, () => {
+    console.warn(`Missing leaf texture: /textures/leaves/${type}.png; skipping.`);
+    leafCache.set(type, null);
+  });
   texture.premultiplyAlpha = true;
   leafCache.set(type, texture);
   return texture;
@@ -82,7 +92,6 @@ export function applyTreeTextures(tree) {
   const barkMaps = getBarkMaps(tree.options.bark.type);
   if (barkMaps) {
     tree.options.bark.maps.color = barkMaps.color;
-    tree.options.bark.maps.ao = barkMaps.ao;
     tree.options.bark.maps.normal = barkMaps.normal;
     tree.options.bark.maps.roughness = barkMaps.roughness;
   }
@@ -94,11 +103,15 @@ export function applyTreeTextures(tree) {
  * the same step so the first generate sees the textures.
  * @param {import('@dgreenheck/ez-tree').Tree} tree
  * @param {string} name - key into TreePreset registry
+ * @param {boolean} generate - set false to skip the generate step when the
+ * caller will generate the tree itself (e.g. via generateLODs)
  */
-export function loadPresetWithTextures(tree, name) {
+export function loadPresetWithTextures(tree, name, generate = true) {
   const json = structuredClone(TreePreset[name]);
   if (!json) return;
   tree.options.copy(json);
   applyTreeTextures(tree);
-  tree.generate();
+  if (generate) {
+    tree.generate();
+  }
 }

--- a/src/app/ui.js
+++ b/src/app/ui.js
@@ -127,9 +127,17 @@ function createSlider(label, value, min, max, step, onChange) {
   valueInput.value = formatValue(value, step);
   valueInput.step = step;
 
+  // Fill the track up to the current value so it reads at a glance
+  const setFill = () => {
+    const pct = ((parseFloat(slider.value) - min) / (max - min || 1)) * 100;
+    slider.style.setProperty('--fill', `${pct}%`);
+  };
+  setFill();
+
   slider.addEventListener('input', (e) => {
     const val = parseFloat(e.target.value);
     valueInput.value = formatValue(val, step);
+    setFill();
     onChange(val);
   });
 
@@ -138,6 +146,7 @@ function createSlider(label, value, min, max, step, onChange) {
     if (isNaN(val)) val = min;
     slider.value = val;
     valueInput.value = formatValue(val, step);
+    setFill();
     onChange(val);
   });
 
@@ -151,6 +160,7 @@ function createSlider(label, value, min, max, step, onChange) {
     setValue: (v) => {
       slider.value = v;
       valueInput.value = formatValue(v, step);
+      setFill();
     }
   };
 }
@@ -330,15 +340,19 @@ function createSection(title, iconKey, expanded = false) {
     ${icons.chevronRight}
   `;
 
+  const contentWrap = document.createElement('div');
+  contentWrap.className = 'section-content';
+
   const content = document.createElement('div');
-  content.className = 'section-content';
+  content.className = 'section-content-inner';
+  contentWrap.appendChild(content);
 
   header.addEventListener('click', () => {
     section.classList.toggle('expanded');
   });
 
   section.appendChild(header);
-  section.appendChild(content);
+  section.appendChild(contentWrap);
 
   return {
     element: section,
@@ -362,8 +376,12 @@ function createSubSection(title, expanded = false) {
     ${icons.chevronRightSmall}
   `;
 
+  const contentWrap = document.createElement('div');
+  contentWrap.className = 'subsection-content';
+
   const content = document.createElement('div');
-  content.className = 'subsection-content';
+  content.className = 'subsection-content-inner';
+  contentWrap.appendChild(content);
 
   header.addEventListener('click', (e) => {
     e.stopPropagation();
@@ -371,7 +389,7 @@ function createSubSection(title, expanded = false) {
   });
 
   section.appendChild(header);
-  section.appendChild(content);
+  section.appendChild(contentWrap);
 
   return {
     element: section,
@@ -410,6 +428,7 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
   const header = document.createElement('div');
   header.className = 'panel-header';
   header.innerHTML = `
+    <div class="panel-grabber" aria-hidden="true"></div>
     <button class="panel-mobile-toggle" aria-label="Toggle panel">
       ${icons.chevronUp}
     </button>
@@ -468,6 +487,7 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
   // its geometry at a chosen level via createGeometry() so it can be
   // inspected at any camera distance without THREE.LOD auto-switching.
   let previewLevel = 0;
+  let lastBuildMs = null;
 
   const statsOverlay = document.createElement('div');
   statsOverlay.id = 'stats-overlay';
@@ -481,6 +501,10 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
         <span class="stats-value" data-stat="vertices">0</span>
         <span class="stats-label">vertices</span>
       </div>
+      <div class="stats-stat">
+        <span class="stats-value" data-stat="buildtime">–</span>
+        <span class="stats-label">build ms</span>
+      </div>
     </div>
     <div class="lod-switcher"></div>
   `;
@@ -488,6 +512,14 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
 
   const statsTriangles = statsOverlay.querySelector('[data-stat="triangles"]');
   const statsVertices = statsOverlay.querySelector('[data-stat="vertices"]');
+  const statsBuildTime = statsOverlay.querySelector('[data-stat="buildtime"]');
+
+  /** Briefly highlights a stat value so live changes are visible */
+  function pulseStat(el) {
+    el.classList.remove('pulse');
+    void el.offsetWidth;
+    el.classList.add('pulse');
+  }
 
   const lodSwitcher = statsOverlay.querySelector('.lod-switcher');
   const lodButtons = Tree.defaultLODLevels.map((level, i) => {
@@ -504,7 +536,9 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
 
   function applyLODPreview() {
     const detail = Tree.defaultLODLevels[previewLevel]?.detail ?? {};
+    const t0 = performance.now();
     const { branches, leaves } = tree.createGeometry(detail);
+    lastBuildMs = performance.now() - t0;
     tree.branchesMesh.geometry.dispose();
     tree.branchesMesh.geometry = branches;
     tree.leavesMesh.geometry.dispose();
@@ -534,7 +568,9 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
 
   const onChange = () => {
     applyTreeTextures(tree);
+    const t0 = performance.now();
     tree.generate();
+    lastBuildMs = performance.now() - t0;
     if (previewLevel > 0) {
       applyLODPreview();
     }
@@ -1027,6 +1063,10 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
     triangleDisplay.setValue(triangles);
     statsVertices.textContent = Math.round(vertices).toLocaleString();
     statsTriangles.textContent = Math.round(triangles).toLocaleString();
+    statsBuildTime.textContent = lastBuildMs == null ? '–' : Math.max(1, Math.round(lastBuildMs)).toString();
+    pulseStat(statsTriangles);
+    pulseStat(statsVertices);
+    pulseStat(statsBuildTime);
   }
 
   // ============================================================================
@@ -1189,11 +1229,12 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
   const footer = document.createElement('div');
   footer.className = 'panel-footer';
   footer.innerHTML = `
-    <a href="https://threejsroadmap.com" target="_blank" class="panel-footer-link">
-      Learn Three.js
-      <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-      </svg>
+    <p class="panel-footer-heading">Enjoying EZ-Tree? Try my other assets</p>
+    <a href="https://threejsroadmap.com/assets/threejs-water-pro?utm_source=eztree" target="_blank" class="panel-footer-link">
+      🌊 Three.js Water Pro
+    </a>
+    <a href="https://threejsroadmap.com/assets/threejs-sky-pro?utm_source=eztree" target="_blank" class="panel-footer-link">
+      ☁️ Three.js Sky Pro
     </a>
   `;
   panel.appendChild(footer);
@@ -1245,15 +1286,18 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
 }
 
 /**
- * Sets up mobile expand/collapse toggle
+ * Sets up the mobile bottom sheet: the whole header is the tap target,
+ * and the panel starts collapsed so the scene stays the hero.
  */
 function setupMobileToggle(panel, header) {
-  const toggleBtn = header.querySelector('.panel-mobile-toggle');
-  if (!toggleBtn) return;
+  const mobileQuery = window.matchMedia('(max-width: 800px)');
 
-  toggleBtn.addEventListener('click', () => {
+  header.addEventListener('click', () => {
+    if (!mobileQuery.matches) return;
     panel.classList.toggle('collapsed');
-    // Trigger resize event so canvas can adjust
-    window.dispatchEvent(new Event('resize'));
   });
+
+  if (mobileQuery.matches) {
+    panel.classList.add('collapsed');
+  }
 }

--- a/src/app/ui.js
+++ b/src/app/ui.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { GLTFExporter } from 'three/addons/exporters/GLTFExporter.js';
+import { zipSync } from 'three/addons/libs/fflate.module.js';
 import { Billboard, TreePreset, Tree, TreeType } from '@dgreenheck/ez-tree';
 import { BarkType, LeafType, applyTreeTextures, loadPresetWithTextures } from './textures';
 import { Environment } from './environment';
@@ -460,12 +461,83 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
   scrollArea.appendChild(exportTab);
 
   // ============================================================================
+  // Stats Overlay (viewport HUD) with LOD preview switching
+  // ============================================================================
+
+  // The hero tree always generates at full detail; the LOD buttons re-mesh
+  // its geometry at a chosen level via createGeometry() so it can be
+  // inspected at any camera distance without THREE.LOD auto-switching.
+  let previewLevel = 0;
+
+  const statsOverlay = document.createElement('div');
+  statsOverlay.id = 'stats-overlay';
+  statsOverlay.innerHTML = `
+    <div class="stats-counts">
+      <div class="stats-stat">
+        <span class="stats-value" data-stat="triangles">0</span>
+        <span class="stats-label">triangles</span>
+      </div>
+      <div class="stats-stat">
+        <span class="stats-value" data-stat="vertices">0</span>
+        <span class="stats-label">vertices</span>
+      </div>
+    </div>
+    <div class="lod-switcher"></div>
+  `;
+  container.appendChild(statsOverlay);
+
+  const statsTriangles = statsOverlay.querySelector('[data-stat="triangles"]');
+  const statsVertices = statsOverlay.querySelector('[data-stat="vertices"]');
+
+  const lodSwitcher = statsOverlay.querySelector('.lod-switcher');
+  const lodButtons = Tree.defaultLODLevels.map((level, i) => {
+    const btn = document.createElement('button');
+    btn.className = 'lod-button' + (i === 0 ? ' active' : '');
+    btn.textContent = i === 0 ? 'Full' : `LOD${i}`;
+    btn.title = i === 0
+      ? 'Full detail'
+      : `Preview detail level ${i} (switches at ${level.distance} units)`;
+    btn.addEventListener('click', () => setPreviewLevel(i));
+    lodSwitcher.appendChild(btn);
+    return btn;
+  });
+
+  function applyLODPreview() {
+    const detail = Tree.defaultLODLevels[previewLevel]?.detail ?? {};
+    const { branches, leaves } = tree.createGeometry(detail);
+    tree.branchesMesh.geometry.dispose();
+    tree.branchesMesh.geometry = branches;
+    tree.leavesMesh.geometry.dispose();
+    tree.leavesMesh.geometry = leaves;
+  }
+
+  function setPreviewLevel(level) {
+    previewLevel = level;
+    lodButtons.forEach((b, i) => b.classList.toggle('active', i === level));
+    applyLODPreview();
+    updateInfoDisplays();
+  }
+
+  /** Vertex/triangle counts of the geometry currently on screen */
+  function displayedCounts() {
+    const gb = tree.branchesMesh.geometry;
+    const gl = tree.leavesMesh.geometry;
+    return {
+      vertices: (gb.attributes.position?.count ?? 0) + (gl.attributes.position?.count ?? 0),
+      triangles: ((gb.index?.count ?? 0) + (gl.index?.count ?? 0)) / 3,
+    };
+  }
+
+  // ============================================================================
   // Parameters Tab Content
   // ============================================================================
 
   const onChange = () => {
     applyTreeTextures(tree);
     tree.generate();
+    if (previewLevel > 0) {
+      applyLODPreview();
+    }
     tree.traverse((o) => {
       if (o.material) {
         o.material.needsUpdate = true;
@@ -483,6 +555,9 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
     initialPreset,
     (val) => {
       loadPresetWithTextures(tree, val);
+      if (previewLevel > 0) {
+        applyLODPreview();
+      }
       refreshAllControls();
     }
   );
@@ -947,8 +1022,11 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
   parametersTab.appendChild(infoSection.element);
 
   function updateInfoDisplays() {
-    vertexDisplay.setValue(tree.vertexCount);
-    triangleDisplay.setValue(tree.triangleCount);
+    const { vertices, triangles } = displayedCounts();
+    vertexDisplay.setValue(vertices);
+    triangleDisplay.setValue(triangles);
+    statsVertices.textContent = Math.round(vertices).toLocaleString();
+    statsTriangles.textContent = Math.round(triangles).toLocaleString();
   }
 
   // ============================================================================
@@ -976,7 +1054,43 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
 
   const exportModelsSection = createSection('Export Models', 'cubeTransparent', true);
 
-  const exportGlbBtn = createButton('Export GLB', 'download', () => {
+  /**
+   * GLTFExporter aborts on textures whose image never loaded (e.g. the
+   * texture file is missing on disk). Rendering tolerates them, so strip
+   * them from the materials for the duration of an export and restore after.
+   * @param {THREE.Object3D} root
+   * @returns {() => void} restore function
+   */
+  function stripBrokenTextures(root) {
+    const restores = [];
+    root.traverse((o) => {
+      const materials = Array.isArray(o.material) ? o.material : o.material ? [o.material] : [];
+      for (const material of materials) {
+        for (const key of ['map', 'aoMap', 'normalMap', 'roughnessMap', 'metalnessMap']) {
+          const texture = material[key];
+          if (texture?.isTexture && !texture.image) {
+            restores.push(() => { material[key] = texture; });
+            material[key] = null;
+          }
+        }
+      }
+    });
+    return () => restores.forEach((restore) => restore());
+  }
+
+  const exportGlbBtn = createButton('Export GLB (Full Detail)', 'download', () => {
+    // Export at full detail regardless of the active LOD preview
+    const restoreLevel = previewLevel;
+    if (restoreLevel !== 0) {
+      setPreviewLevel(0);
+    }
+    const restoreTextures = stripBrokenTextures(tree);
+    const restore = () => {
+      restoreTextures();
+      if (restoreLevel !== 0) {
+        setPreviewLevel(restoreLevel);
+      }
+    };
     exporter.parse(
       tree,
       (glb) => {
@@ -986,14 +1100,56 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
         link.href = url;
         link.download = 'tree.glb';
         link.click();
+        restore();
       },
       (err) => {
         console.error(err);
+        restore();
       },
       { binary: true }
     );
   });
   exportModelsSection.add(exportGlbBtn);
+
+  const exportLodsBtn = createButton('Export LODs (ZIP)', 'archive', async () => {
+    const restoreTextures = stripBrokenTextures(tree);
+    try {
+      const files = {};
+      for (let i = 0; i < Tree.defaultLODLevels.length; i++) {
+        const { detail } = Tree.defaultLODLevels[i];
+        const { branches, leaves } = tree.createGeometry(detail ?? {});
+
+        try {
+          const branchesMesh = new THREE.Mesh(branches, tree.branchesMesh.material);
+          branchesMesh.name = `Branches_LOD${i}`;
+          const leavesMesh = new THREE.Mesh(leaves, tree.leavesMesh.material);
+          leavesMesh.name = `Leaves_LOD${i}`;
+          const group = new THREE.Group();
+          group.name = `Tree_LOD${i}`;
+          group.add(branchesMesh, leavesMesh);
+
+          const glb = await new Promise((resolve, reject) =>
+            exporter.parse(group, resolve, reject, { binary: true }),
+          );
+          files[`tree_LOD${i}.glb`] = new Uint8Array(glb);
+        } finally {
+          branches.dispose();
+          leaves.dispose();
+        }
+      }
+
+      const blob = new Blob([zipSync(files)], { type: 'application/zip' });
+      const link = document.getElementById('downloadLink');
+      link.href = URL.createObjectURL(blob);
+      link.download = 'tree_lods.zip';
+      link.click();
+    } catch (err) {
+      console.error(err);
+    } finally {
+      restoreTextures();
+    }
+  });
+  exportModelsSection.add(exportLodsBtn);
 
   const exportPngBtn = createButton('Export PNG', 'photo', () => {
     renderer.setClearColor(0, 0);
@@ -1058,6 +1214,9 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
         try {
           tree.options = JSON.parse(e.target.result);
           tree.generate();
+          if (previewLevel > 0) {
+            applyLODPreview();
+          }
           refreshAllControls();
         } catch (error) {
           console.error('Error parsing JSON:', error);
@@ -1077,6 +1236,9 @@ export function setupUI(tree, environment, renderer, scene, camera, orbitControl
     controls.forEach(({ update }) => update());
     updateInfoDisplays();
   }
+
+  // Initialize the stats overlay with the current tree's counts
+  updateInfoDisplays();
 
   // Mobile expand/collapse functionality
   setupMobileToggle(panel, header);

--- a/src/lib/tree.js
+++ b/src/lib/tree.js
@@ -31,6 +31,8 @@ export class Tree extends THREE.Group {
     this.branchesMesh = new THREE.Mesh();
     this.leavesMesh = new THREE.Mesh();
     this.trellisMesh = null;
+    this.lod = null;
+    this.skeleton = null;
     this.add(this.branchesMesh);
     this.add(this.leavesMesh);
     this.options = options;
@@ -62,23 +64,190 @@ export class Tree extends THREE.Group {
   }
 
   /**
+   * @typedef {Object} LODDetail
+   * @property {number} [sectionStride=1] Sample every Nth section ring; the
+   *   first and last rings are always kept so branch endpoints stay put
+   * @property {number} [segmentFactor=1] Radial segment multiplier;
+   *   segments = max(3, round(segmentCount * segmentFactor))
+   * @property {number} [leafStride=1] Keep every Nth leaf
+   * @property {number} [leafScale=1] Size multiplier for the kept leaves,
+   *   typically 1/sqrt(kept fraction) to preserve canopy coverage
+   * @property {string} [billboard] Billboard mode override for this level
+   *   ('single' or 'double'); defaults to options.leaves.billboard
+   */
+
+  /**
+   * @typedef {Object} LODLevel
+   * @property {number} distance Camera distance at which this level activates
+   * @property {number} [hysteresis] Switch hysteresis as a fraction of distance
+   * @property {LODDetail} [detail] Meshing detail for this level
+   */
+
+  /**
+   * Default levels for generateLODs(). LOD1 is roughly 40% of the full
+   * triangle count, LOD2 roughly 20%.
+   * @type {LODLevel[]}
+   */
+  static defaultLODLevels = [
+    { distance: 0, detail: {} },
+    {
+      distance: 100,
+      hysteresis: 0.05,
+      detail: {
+        sectionStride: 3,
+        segmentFactor: 0.75,
+        leafStride: 2,
+        // Slightly under the area-preserving sqrt(2): individual leaves are
+        // still resolvable at this distance, so a full compensation reads as
+        // "bigger leaves" rather than "same canopy".
+        leafScale: 1.25,
+      },
+    },
+    {
+      distance: 250,
+      hysteresis: 0.05,
+      detail: {
+        sectionStride: 6,
+        segmentFactor: 0.4,
+        leafStride: 2,
+        // Deliberately under-compensated: full coverage compensation for the
+        // thinning + single billboard would need 2x scale, which reads as
+        // balloon leaves. A slightly sparser canopy with natural-size leaves
+        // looks better at this distance (fogged, 250+ units in the demo).
+        leafScale: 1.3,
+        billboard: Billboard.Single,
+      },
+    },
+  ];
+
+  /**
    * Generate a new tree
    */
   generate() {
-    // Clean up old geometry
-    this.branches = {
-      verts: [],
-      normals: [],
-      indices: [],
-      uvs: [],
-      windFactor: []
-    };
+    this.#clearLOD();
+    this.#generateSkeleton();
 
-    this.leaves = {
-      verts: [],
-      normals: [],
-      indices: [],
-      uvs: [],
+    const buffers = this.#meshSkeleton();
+    this.branches = buffers.branches;
+    this.leaves = buffers.leaves;
+
+    this.createBranchesGeometry();
+    this.createLeavesGeometry();
+    this.createTrellis();
+  }
+
+  /**
+   * Generates the tree as a set of levels of detail hosted in a THREE.LOD
+   * object inside this group. The renderer switches levels automatically
+   * based on camera distance. All levels share one bark and one leaf
+   * material, so update() animates wind at every level.
+   * @param {LODLevel[]} levels Level descriptors, in any order
+   */
+  generateLODs(levels = Tree.defaultLODLevels) {
+    this.#clearLOD();
+    this.#generateSkeleton();
+
+    const barkMaterial = this.#createBarkMaterial();
+    const leafMaterial = this.#createLeafMaterial();
+
+    this.lod = new THREE.LOD();
+    this.lod.name = 'TreeLOD';
+
+    // THREE.LOD sorts its levels by distance internally, so sort here too and
+    // let the nearest level own the reused meshes regardless of input order.
+    const ordered = [...levels].sort(
+      (a, b) => (a.distance ?? 0) - (b.distance ?? 0),
+    );
+
+    ordered.forEach((level, index) => {
+      const buffers = this.#meshSkeleton(level.detail ?? {});
+
+      let branchesMesh, leavesMesh;
+      if (index === 0) {
+        // Reuse the existing meshes for the closest level so update(),
+        // traversal and the vertex/triangle count getters keep working.
+        this.branches = buffers.branches;
+        this.leaves = buffers.leaves;
+        branchesMesh = this.branchesMesh;
+        leavesMesh = this.leavesMesh;
+        branchesMesh.geometry.dispose();
+        branchesMesh.material.dispose();
+        leavesMesh.geometry.dispose();
+        leavesMesh.material.dispose();
+      } else {
+        branchesMesh = new THREE.Mesh();
+        leavesMesh = new THREE.Mesh();
+      }
+
+      branchesMesh.geometry = this.#buildBufferGeometry(buffers.branches);
+      branchesMesh.material = barkMaterial;
+      leavesMesh.geometry = this.#buildBufferGeometry(buffers.leaves);
+      leavesMesh.material = leafMaterial;
+
+      for (const mesh of [branchesMesh, leavesMesh]) {
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+      }
+
+      const group = new THREE.Group();
+      group.add(branchesMesh, leavesMesh);
+      this.lod.addLevel(group, level.distance ?? 0, level.hysteresis ?? 0);
+    });
+
+    this.add(this.lod);
+    this.createTrellis();
+  }
+
+  /**
+   * Builds branch and leaf geometry at the given detail level without
+   * modifying the tree's own meshes. Useful for external instancing or
+   * custom LOD systems. Reuses the current skeleton, generating one first
+   * if none exists.
+   * @param {LODDetail} detail
+   * @returns {{ branches: THREE.BufferGeometry, leaves: THREE.BufferGeometry }}
+   */
+  createGeometry(detail = {}) {
+    if (!this.skeleton) {
+      this.#generateSkeleton();
+    }
+    const buffers = this.#meshSkeleton(detail);
+    return {
+      branches: this.#buildBufferGeometry(buffers.branches),
+      leaves: this.#buildBufferGeometry(buffers.leaves),
+    };
+  }
+
+  /**
+   * Tears down any LOD state and restores the flat branches/leaves meshes
+   * as direct children, so generate() behaves as if LODs never existed.
+   */
+  #clearLOD() {
+    if (!this.lod) return;
+
+    this.lod.levels.forEach((level) => {
+      for (const mesh of level.object.children) {
+        // One level reuses branchesMesh/leavesMesh; their geometry and the
+        // shared materials are disposed by whichever generate path runs next.
+        if (mesh === this.branchesMesh || mesh === this.leavesMesh) continue;
+        mesh.geometry.dispose();
+      }
+    });
+
+    this.remove(this.lod);
+    this.lod = null;
+    this.add(this.branchesMesh, this.leavesMesh);
+  }
+
+  /**
+   * Grows the tree skeleton: the section frames of every branch and the
+   * placement of every leaf. All RNG consumption happens here, so any
+   * number of meshing passes can run against one skeleton without changing
+   * the tree's shape.
+   */
+  #generateSkeleton() {
+    this.skeleton = {
+      branches: [],
+      leaves: [],
     };
 
     this.rng = new RNG(this.options.seed);
@@ -98,23 +267,56 @@ export class Tree extends THREE.Group {
 
     while (this.branchQueue.length > 0) {
       const branch = this.branchQueue.shift();
-      this.generateBranch(branch);
+      this.#growBranch(branch);
     }
-
-    this.createBranchesGeometry();
-    this.createLeavesGeometry();
-    this.createTrellis();
   }
 
   /**
-   * Generates a new branch
+   * Meshes the current skeleton into geometry buffers at the given detail.
+   * Consumes no RNG, so it can run repeatedly with different detail specs.
+   * @param {LODDetail} detail
+   */
+  #meshSkeleton(detail = {}) {
+    const sectionStride = Math.max(1, Math.floor(detail.sectionStride ?? 1));
+    const segmentFactor = detail.segmentFactor ?? 1;
+    const leafStride = Math.max(1, Math.floor(detail.leafStride ?? 1));
+    const leafScale = detail.leafScale ?? 1;
+    const billboard = detail.billboard ?? this.options.leaves.billboard;
+
+    const branches = {
+      verts: [],
+      normals: [],
+      indices: [],
+      uvs: [],
+      windFactor: []
+    };
+
+    const leaves = {
+      verts: [],
+      normals: [],
+      indices: [],
+      uvs: [],
+    };
+
+    for (const skeletonBranch of this.skeleton.branches) {
+      this.#meshBranch(branches, skeletonBranch, sectionStride, segmentFactor);
+    }
+
+    for (let i = 0; i < this.skeleton.leaves.length; i += leafStride) {
+      this.#meshLeaf(leaves, this.skeleton.leaves[i], leafScale, billboard);
+    }
+
+    return { branches, leaves };
+  }
+
+  /**
+   * Grows a branch's skeleton, queueing child branches and recording leaf
+   * placements. Consumes RNG in the exact order of the original interleaved
+   * generator so seeds keep producing identical trees.
    * @param {Branch} branch
    * @returns
    */
-  generateBranch(branch) {
-    // Used later for geometry index generation
-    const indexOffset = this.branches.verts.length / 3;
-
+  #growBranch(branch) {
     let sectionOrientation = branch.orientation.clone();
     let sectionOrigin = branch.origin.clone();
     let sectionLength =
@@ -125,15 +327,6 @@ export class Tree extends THREE.Group {
     // This information is used for generating child branches after the branch
     // geometry has been constructed
     let sections = [];
-
-    // Number of texture wraps around the branch's circumference. Scaling with
-    // branch.radius keeps bark feature size roughly consistent across thick
-    // trunks and thin twigs. Held constant for the whole branch so tapered
-    // sections share a wrap count and don't twist the texture longitudinally.
-    const wrapsX = Math.max(
-      1,
-      Math.round(branch.radius * this.options.bark.textureScale.x),
-    );
 
     for (let i = 0; i <= branch.sectionCount; i++) {
       let sectionRadius = branch.radius;
@@ -151,41 +344,6 @@ export class Tree extends THREE.Group {
         // Evergreens do not have a terminal branch so they have a taper of 1
         sectionRadius *= 1 - (i / branch.sectionCount);
       }
-
-      // Create the segments that make up this section.
-      let first;
-      for (let j = 0; j < branch.segmentCount; j++) {
-        let angle = (2.0 * Math.PI * j) / branch.segmentCount;
-
-        // Create the segment vertex
-        const vertex = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle))
-          .multiplyScalar(sectionRadius)
-          .applyEuler(sectionOrientation)
-          .add(sectionOrigin);
-
-        const normal = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle))
-          .applyEuler(sectionOrientation)
-          .normalize();
-
-        const uv = new THREE.Vector2(
-          (j / branch.segmentCount) * wrapsX,
-          (i % 2 === 0) ? 0 : 1,
-        );
-
-        this.branches.verts.push(...Object.values(vertex));
-        this.branches.normals.push(...Object.values(normal));
-        this.branches.uvs.push(...Object.values(uv));
-
-        if (j === 0) {
-          first = { vertex, normal, uv };
-        }
-      }
-
-      // Duplicate the first vertex so there is continuity in the UV mapping.
-      // u=wrapsX maps to the same texel as u=0 since wrapsX is an integer.
-      this.branches.verts.push(...Object.values(first.vertex));
-      this.branches.normals.push(...Object.values(first.normal));
-      this.branches.uvs.push(wrapsX, first.uv.y);
 
       // Use this information later on when generating child branches
       sections.push({
@@ -255,7 +413,11 @@ export class Tree extends THREE.Group {
       sectionOrientation.setFromQuaternion(qSection);
     }
 
-    this.generateBranchIndices(indexOffset, branch);
+    this.skeleton.branches.push({
+      sections,
+      segmentCount: branch.segmentCount,
+      baseRadius: branch.radius,
+    });
 
     // Deciduous trees have a terminal branch that grows out of the
     // end of the parent branch
@@ -277,7 +439,7 @@ export class Tree extends THREE.Group {
           ),
         );
       } else {
-        this.generateLeaf(lastSection.origin, lastSection.orientation);
+        this.#recordLeaf(lastSection.origin, lastSection.orientation);
       }
     }
 
@@ -457,26 +619,46 @@ export class Tree extends THREE.Group {
         q3.multiply(q2.multiply(q1)),
       );
 
-      this.generateLeaf(leafOrigin, leafOrientation);
+      this.#recordLeaf(leafOrigin, leafOrientation);
     }
   }
 
   /**
-  * Generates a leaves
-  * @param {THREE.Vector3} origin The starting point of the branch
-  * @param {THREE.Euler} orientation The starting orientation of the branch
+  * Records a leaf placement in the skeleton. The size variance is sampled
+  * here so the meshing passes stay RNG-free.
+  * @param {THREE.Vector3} origin The starting point of the leaf
+  * @param {THREE.Euler} orientation The orientation of the leaf
   */
-  generateLeaf(origin, orientation) {
-    let i = this.leaves.verts.length / 3;
-
-    // Width and length of the leaf quad
-    let leafSize =
+  #recordLeaf(origin, orientation) {
+    const size =
       this.options.leaves.size *
       (1 +
         this.rng.random(
           this.options.leaves.sizeVariance,
           -this.options.leaves.sizeVariance,
         ));
+
+    this.skeleton.leaves.push({
+      origin: origin.clone(),
+      orientation: orientation.clone(),
+      size,
+    });
+  }
+
+  /**
+  * Emits the quad geometry for one skeleton leaf into the buffers
+  * @param {{verts: number[], normals: number[], indices: number[], uvs: number[]}} buffers
+  * @param {{origin: THREE.Vector3, orientation: THREE.Euler, size: number}} leaf
+  * @param {number} scale Size multiplier for this detail level
+  * @param {string} billboard Billboard mode for this detail level
+  */
+  #meshLeaf(buffers, leaf, scale, billboard) {
+    let i = buffers.verts.length / 3;
+
+    const { origin, orientation } = leaf;
+
+    // Width and length of the leaf quad
+    const leafSize = leaf.size * scale;
 
     const W = leafSize;
     const L = leafSize;
@@ -495,7 +677,7 @@ export class Tree extends THREE.Group {
           .add(origin),
       );
 
-      this.leaves.verts.push(
+      buffers.verts.push(
         v[0].x,
         v[0].y,
         v[0].z,
@@ -520,7 +702,7 @@ export class Tree extends THREE.Group {
       let n3 = roundedNormals ? new THREE.Vector3().copy(n).add(v[2]).sub(origin).normalize() : n;
       let n4 = roundedNormals ? new THREE.Vector3().copy(n).add(v[3]).sub(origin).normalize() : n;
 
-      this.leaves.normals.push(
+      buffers.normals.push(
         n1.x,
         n1.y,
         n1.z,
@@ -534,13 +716,13 @@ export class Tree extends THREE.Group {
         n4.y,
         n4.z,
       );
-      this.leaves.uvs.push(0, 1, 0, 0, 1, 0, 1, 1);
-      this.leaves.indices.push(i, i + 1, i + 2, i, i + 2, i + 3);
+      buffers.uvs.push(0, 1, 0, 0, 1, 0, 1, 1);
+      buffers.indices.push(i, i + 1, i + 2, i, i + 2, i + 3);
       i += 4;
     };
 
     createLeaf(0);
-    if (this.options.leaves.billboard === Billboard.Double) {
+    if (billboard === Billboard.Double) {
       createLeaf(Math.PI / 2);
     }
   }
@@ -561,56 +743,140 @@ export class Tree extends THREE.Group {
   }
 
   /**
-   * Generates the indices for branch geometry
-   * @param {Branch} branch
+   * Emits the ring geometry and indices for one skeleton branch
+   * @param {{verts: number[], normals: number[], indices: number[], uvs: number[]}} buffers
+   * @param {{sections: {origin: THREE.Vector3, orientation: THREE.Euler, radius: number}[], segmentCount: number, baseRadius: number}} skeletonBranch
+   * @param {number} sectionStride Sample every Nth section ring
+   * @param {number} segmentFactor Radial segment multiplier
    */
-  generateBranchIndices(indexOffset, branch) {
-    // Build geometry each section of the branch (cylinder without end caps)
+  #meshBranch(buffers, skeletonBranch, sectionStride, segmentFactor) {
+    const { sections, segmentCount, baseRadius } = skeletonBranch;
+
+    // Terminal branches inherit the parent's segmentCount, so parent and
+    // child resolve to the same reduced count and junctions stay sealed.
+    const segments = Math.max(3, Math.round(segmentCount * segmentFactor));
+
+    // Number of texture wraps around the branch's circumference. Scaling with
+    // the branch's base radius keeps bark feature size roughly consistent
+    // across thick trunks and thin twigs. Held constant for the whole branch
+    // so tapered sections share a wrap count and don't twist the texture
+    // longitudinally.
+    const wrapsX = Math.max(
+      1,
+      Math.round(baseRadius * this.options.bark.textureScale.x),
+    );
+
+    // Sample every Nth ring, always keeping the first and last so branch
+    // endpoints (and parent/child junctions) stay put across detail levels.
+    const sampled = [];
+    for (let i = 0; i < sections.length; i += sectionStride) {
+      sampled.push(sections[i]);
+    }
+    if ((sections.length - 1) % sectionStride !== 0) {
+      sampled.push(sections[sections.length - 1]);
+    }
+
+    // Used later for geometry index generation
+    const indexOffset = buffers.verts.length / 3;
+
+    for (let k = 0; k < sampled.length; k++) {
+      const section = sampled[k];
+
+      // Create the segments that make up this section.
+      let first;
+      for (let j = 0; j < segments; j++) {
+        let angle = (2.0 * Math.PI * j) / segments;
+
+        // Create the segment vertex
+        const vertex = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle))
+          .multiplyScalar(section.radius)
+          .applyEuler(section.orientation)
+          .add(section.origin);
+
+        const normal = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle))
+          .applyEuler(section.orientation)
+          .normalize();
+
+        // uv.y alternates by sampled ring position rather than original
+        // section index, so section skipping keeps the 0/1 tiling pattern.
+        const uv = new THREE.Vector2(
+          (j / segments) * wrapsX,
+          (k % 2 === 0) ? 0 : 1,
+        );
+
+        buffers.verts.push(...Object.values(vertex));
+        buffers.normals.push(...Object.values(normal));
+        buffers.uvs.push(...Object.values(uv));
+
+        if (j === 0) {
+          first = { vertex, normal, uv };
+        }
+      }
+
+      // Duplicate the first vertex so there is continuity in the UV mapping.
+      // u=wrapsX maps to the same texel as u=0 since wrapsX is an integer.
+      buffers.verts.push(...Object.values(first.vertex));
+      buffers.normals.push(...Object.values(first.normal));
+      buffers.uvs.push(wrapsX, first.uv.y);
+    }
+
+    // Build geometry for each section of the branch (cylinder without end caps)
     let v1, v2, v3, v4;
-    const N = branch.segmentCount + 1;
-    for (let i = 0; i < branch.sectionCount; i++) {
+    const N = segments + 1;
+    for (let i = 0; i < sampled.length - 1; i++) {
       // Build the quad for each segment of the section
-      for (let j = 0; j < branch.segmentCount; j++) {
+      for (let j = 0; j < segments; j++) {
         v1 = indexOffset + i * N + j;
         // The last segment wraps around back to the starting segment, so omit j + 1 term
         v2 = indexOffset + i * N + (j + 1);
         v3 = v1 + N;
         v4 = v2 + N;
-        this.branches.indices.push(v1, v3, v2, v2, v3, v4);
+        buffers.indices.push(v1, v3, v2, v2, v3, v4);
       }
     }
   }
 
   /**
-   * Generates the geometry for the branches
+   * Builds a BufferGeometry from raw attribute buffers
+   * @param {{verts: number[], normals: number[], indices: number[], uvs: number[]}} buffers
+   * @returns {THREE.BufferGeometry}
    */
-  createBranchesGeometry() {
+  #buildBufferGeometry(buffers) {
     const g = new THREE.BufferGeometry();
     g.setAttribute(
       'position',
-      new THREE.BufferAttribute(new Float32Array(this.branches.verts), 3),
+      new THREE.BufferAttribute(new Float32Array(buffers.verts), 3),
     );
     g.setAttribute(
       'normal',
-      new THREE.BufferAttribute(new Float32Array(this.branches.normals), 3),
+      new THREE.BufferAttribute(new Float32Array(buffers.normals), 3),
     );
     g.setAttribute(
       'uv',
-      new THREE.BufferAttribute(new Float32Array(this.branches.uvs), 2),
+      new THREE.BufferAttribute(new Float32Array(buffers.uvs), 2),
     );
     g.setIndex(
-      new THREE.BufferAttribute(new Uint16Array(this.branches.indices), 1),
+      new THREE.BufferAttribute(new Uint16Array(buffers.indices), 1),
     );
     g.computeBoundingSphere();
+    return g;
+  }
 
-    const mat = new THREE.MeshPhongMaterial({
+  /**
+   * Creates the bark material from the current options
+   * @returns {THREE.MeshStandardMaterial}
+   */
+  #createBarkMaterial() {
+    const mat = new THREE.MeshStandardMaterial({
       name: 'branches',
       flatShading: this.options.bark.flatShading,
       color: new THREE.Color(this.options.bark.tint),
+      metalness: 0.0,
+      roughness: 1.0,
     });
 
     if (this.options.bark.textured) {
-      // textureScale.x is baked into UVs in generateBranch (wrapsX), so only
+      // textureScale.x is baked into UVs during meshing (wrapsX), so only
       // the Y axis needs runtime scaling on the texture itself.
       const scale = this.options.bark.textureScale;
       const maps = this.options.bark.maps;
@@ -625,46 +891,45 @@ export class Tree extends THREE.Group {
       if (maps.color) mat.map = apply(maps.color);
       if (maps.ao) mat.aoMap = apply(maps.ao);
       if (maps.normal) mat.normalMap = apply(maps.normal);
-      if (maps.roughness) mat.roughnessMap = apply(maps.roughness);
+      if (maps.roughness) {
+        mat.roughnessMap = apply(maps.roughness);
+        // Point metalnessMap at the same texture: metalness stays 0 because
+        // the metalness factor is 0, and GLTFExporter reuses the texture
+        // as-is instead of synthesizing a merged metal/rough PNG (and
+        // warning about it) when the two slots differ.
+        mat.metalnessMap = mat.roughnessMap;
+      }
     }
 
+    return mat;
+  }
+
+  /**
+   * Generates the geometry for the branches
+   */
+  createBranchesGeometry() {
     this.branchesMesh.geometry.dispose();
-    this.branchesMesh.geometry = g;
+    this.branchesMesh.geometry = this.#buildBufferGeometry(this.branches);
     this.branchesMesh.material.dispose();
-    this.branchesMesh.material = mat;
+    this.branchesMesh.material = this.#createBarkMaterial();
     this.branchesMesh.castShadow = true;
     this.branchesMesh.receiveShadow = true;
   }
 
   /**
-   * Generates the geometry for the leaves
+   * Creates the leaf material, including the wind sway vertex shader, from
+   * the current options
+   * @returns {THREE.MeshStandardMaterial}
    */
-  createLeavesGeometry() {
-    const g = new THREE.BufferGeometry();
-    g.setAttribute(
-      'position',
-      new THREE.BufferAttribute(new Float32Array(this.leaves.verts), 3),
-    );
-    g.setAttribute(
-      'uv',
-      new THREE.BufferAttribute(new Float32Array(this.leaves.uvs), 2),
-    );
-    g.setIndex(
-      new THREE.BufferAttribute(new Uint16Array(this.leaves.indices), 1),
-    );
-    g.setAttribute(
-      'normal',
-      new THREE.BufferAttribute(new Float32Array(this.leaves.normals), 3),
-    );
-
-    g.computeBoundingSphere();
-
-    const mat = new THREE.MeshPhongMaterial({
+  #createLeafMaterial() {
+    const mat = new THREE.MeshStandardMaterial({
       name: 'leaves',
       map: this.options.leaves.map ?? null,
       color: new THREE.Color(this.options.leaves.tint),
       side: THREE.DoubleSide,
       alphaTest: this.options.leaves.alphaTest,
+      metalness: 0.0,
+      roughness: 1.0,
       dithering: true
     });
 
@@ -810,15 +1075,27 @@ export class Tree extends THREE.Group {
         )
       );
 
-      mat.userData.shader = shader;
+      // Non-enumerable so JSON serialization (e.g. GLTFExporter's userData
+      // pass) skips the live shader object — Texture uniforms inside it are
+      // not serializable. update() still reads userData.shader normally.
+      Object.defineProperty(mat.userData, 'shader', {
+        value: shader,
+        configurable: true,
+        enumerable: false,
+      });
     };
 
+    return mat;
+  }
+
+  /**
+   * Generates the geometry for the leaves
+   */
+  createLeavesGeometry() {
     this.leavesMesh.geometry.dispose();
-    this.leavesMesh.geometry = g;
+    this.leavesMesh.geometry = this.#buildBufferGeometry(this.leaves);
     this.leavesMesh.material.dispose();
-
-    this.leavesMesh.material = mat;
-
+    this.leavesMesh.material = this.#createLeafMaterial();
     this.leavesMesh.castShadow = true;
     this.leavesMesh.receiveShadow = true;
   }


### PR DESCRIPTION
## Summary

Release PR for v2.0.0. See [CHANGELOG.md](https://github.com/dgreenheck/ez-tree/blob/release/v2.0.0/CHANGELOG.md) for full details.

### Levels of Detail (#45)
- `Tree.generateLODs(levels)` builds the tree at multiple detail levels in a `THREE.LOD` with automatic distance-based switching — all levels share one skeleton (no silhouette pop) and one set of materials (wind animates at every level).
- `Tree.createGeometry(detail)` returns raw `{ branches, leaves }` geometry at any detail level for external instancing or custom LOD systems.
- Demo app: forest generates with LODs, live triangle/vertex stats overlay with LOD preview buttons, and "Export LODs (ZIP)" download.

### Texture System (breaking)
- The library no longer bundles textures. `BarkType`/`LeafType` enums are removed; callers supply `THREE.Texture` instances via `bark.maps` and `leaves.map`.
- Bark UVs now scale with branch radius so bark feature size stays consistent from trunk to twig.

### Rendering
- Bark, leaf, ground, and grass materials moved from Phong to `MeshStandardMaterial` (PBR); GLB exports round-trip cleanly.
- Leaves use custom rounded normals for softer canopy shading (#43).

### Bug Fixes
- Fixed silent GLB export failure caused by never-loaded textures.
- Fixed growth force so branches grow uniformly in the same world direction.
- Stratified sampling for child branch and leaf placement eliminates visible spirals and clumping.

### Demo App
- Refreshed the UI with a glassmorphism design: tinted-glass panels and dialogs, canopy-green accent palette, Space Grotesk typography, filled slider tracks, live build-time stat, and a mobile bottom-sheet layout.

### Development & Tooling
- `npm run dev` with Vite alias for instant HMR against library source.
- Reorganized `src/app/public/` assets; bark textures tracked via Git LFS.
- Dockerfile updated to Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
